### PR TITLE
Avoid MySQL syntax error when using truncation + DataMapper

### DIFF
--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -30,7 +30,7 @@ module DataMapper
           execute("SET FOREIGN_KEY_CHECKS = 0;")
           yield
         ensure
-          execute("SET FOREIGN_KEY_CHECKS = #{old.first};")
+          execute("SET FOREIGN_KEY_CHECKS = ?", *old)
         end
       end
 


### PR DESCRIPTION
I was getting a syntax error due to this line attempting to run: `SET FOREIGN_KEY_CHECKS = [1]`

I altered this, at dkubb's advice, to fill in a pointer to the original variable instead. No more error is raised during truncation.
