### PR TITLE
Compatibility with activerecord-jdbc-adapter version 1.0.2

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -5,14 +5,18 @@ require 'database_cleaner/active_record/base'
 
 module ActiveRecord
   module ConnectionAdapters
-
+    # Activerecord-jdbc-adapter defines class dependencies a bit differently - if it is present, confirm to ArJdbc hierarchy to avoid 'superclass mismatch' errors.
+    USE_ARJDBC_WORKAROUND = defined?(ArJdbc)
+    
     class AbstractAdapter
     end
-
-    class SQLiteAdapter < AbstractAdapter
+    
+    unless USE_ARJDBC_WORKAROUND
+      class SQLiteAdapter < AbstractAdapter
+      end
     end
 
-    class MysqlAdapter < AbstractAdapter
+    class MysqlAdapter < (USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter)
       def truncate_table(table_name)
         execute("TRUNCATE TABLE #{quote_table_name(table_name)};")
       end
@@ -24,7 +28,7 @@ module ActiveRecord
       end
     end
 
-    class SQLite3Adapter < SQLiteAdapter
+    class SQLite3Adapter < (USE_ARJDBC_WORKAROUND ? JdbcAdapter : SQLiteAdapter)
       def truncate_table(table_name)
         execute("DELETE FROM #{quote_table_name(table_name)};")
       end


### PR DESCRIPTION
Hi,
I ran into a 'superclass mismatch' error with database_cleaner and activerecord-jdbc-adapter. I traced it down to the way ArJdbc defines class inheritance. Here's my idea how to fix it. Seems to work on my project (JRuby 1.5.2, activerecord-jdbc-adapter 1.0.2, MySQL), but I have not done proper testing on other versions due to time constraints :(
