### PR TITLE
Exclude views from tables_to_truncate

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+== 0.6.2 (In Git)
+  * Exclude database views from tables_to_truncate, if the connection adapter
+    supports reading from the ANSI standard information_schema views. (Samer Abukhait)
+
 == 0.6.1 (In Git)
 
  === Bugfixes

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,6 +1,6 @@
---- 
+---
 :minor: 6
-:patch: 0
-:build: 
+:patch: 2
+:build:
 :major: 0
 

--- a/database_cleaner.gemspec
+++ b/database_cleaner.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{database_cleaner}
-  s.version = "0.6.0"
+  s.version = "0.6.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ben Mabey"]
-  s.date = %q{2010-10-25}
+  s.date = %q{2010-11-24}
   s.description = %q{Strategies for cleaning databases.  Can be used to ensure a clean state for testing.}
   s.email = %q{ben@benmabey.com}
   s.extra_rdoc_files = [

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -9,6 +9,9 @@ module ActiveRecord
     USE_ARJDBC_WORKAROUND = defined?(ArJdbc)
 
     class AbstractAdapter
+      def views
+        @views ||= select_values("select table_name from information_schema.views where table_schema = '#{current_database}'") rescue []
+      end
     end
 
     unless USE_ARJDBC_WORKAROUND
@@ -99,7 +102,7 @@ module DatabaseCleaner::ActiveRecord
     private
 
     def tables_to_truncate
-       (@only || connection.tables) - @tables_to_exclude
+       (@only || connection.tables) - @tables_to_exclude - connection.views
     end
 
     def connection

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -22,6 +22,7 @@ module DatabaseCleaner
 
       before(:each) do
         connection.stub!(:disable_referential_integrity).and_yield
+        connection.stub!(:views).and_return([])
         ::ActiveRecord::Base.stub!(:connection).and_return(connection)
       end
 
@@ -62,6 +63,17 @@ module DatabaseCleaner
       it "should raise an error when invalid options are provided" do
         running { Truncation.new(:foo => 'bar') }.should raise_error(ArgumentError)
       end
+
+      it "should not truncate views" do
+        connection.stub!(:tables).and_return(%w[widgets dogs])
+        connection.stub!(:views).and_return(["widgets"])
+
+        connection.should_receive(:truncate_table).with('dogs')
+        connection.should_not_receive(:truncate_table).with('widgets')
+
+        Truncation.new.clean
+      end
+
     end
   end
 end


### PR DESCRIPTION
Exclude database views from tables_to_truncate, if the connection adapter supports reading from the ANSI standard information_schema views
