### PR TITLE
Partial fix to issue #23

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -27,8 +27,10 @@ module DatabaseCleaner
       end
 
       def load_config
-        connection_details = YAML::load(ERB.new(IO.read(ActiveRecord.config_file_location)).result)
-        self.connection_hash = connection_details[self.db.to_s]
+        if File.file?(ActiveRecord.config_file_location)
+          connection_details   = YAML::load(ERB.new(IO.read(ActiveRecord.config_file_location)).result)
+          self.connection_hash = connection_details[self.db.to_s]
+        end
       end
 
       def create_connection_klass

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -24,8 +24,11 @@ module DatabaseCleaner
     end
 
     describe ExampleStrategy do
+      let :config_location do
+        '/path/to/config/database.yml'
+      end
 
-      before { ::DatabaseCleaner::ActiveRecord.stub(:config_file_location).and_return('/path/to/config/database.yml') }
+      before { ::DatabaseCleaner::ActiveRecord.stub(:config_file_location).and_return(config_location) }
 
       it_should_behave_like "a generic strategy"
 
@@ -58,7 +61,8 @@ module DatabaseCleaner
 my_db:
   database: <%= "ONE".downcase %>
           Y
-          IO.stub(:read).with('/path/to/config/database.yml').and_return(yaml)
+          File.stub(:file?).with(config_location).and_return(true)
+          IO.stub(:read).with(config_location).and_return(yaml)
         end
 
         it "should parse the config" do
@@ -79,6 +83,12 @@ my_db:
           subject.should_receive(:db).and_return(:my_db)
           subject.load_config
           subject.connection_hash.should == {"database" => "one"}
+        end
+
+        it "should skip config if config file is not available" do
+          File.should_receive(:file?).with(config_location).and_return(false)
+          subject.load_config
+          subject.connection_hash.should be_blank
         end
       end
 


### PR DESCRIPTION
A small fix to check if config/database.yml file exists before loading connection configuration from it. Life saver for all of us who use database_cleaner not only with Rails.
