### PR TITLE
Don't attempt to truncate postgres views

### DIFF
--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -101,7 +101,7 @@ module DataMapper
       def storage_names(repository = :default)
         sql = <<-SQL.compress_lines
           SELECT table_name FROM "information_schema"."tables"
-          WHERE table_schema = current_schema()
+          WHERE table_schema = current_schema() and table_type = 'BASE TABLE'
         SQL
         select(sql)
       end


### PR DESCRIPTION
This ensures that only proper tables are truncated, rather than attempting to truncate views (which isn't possible).
