### PR TITLE
Fix for skipping the MongoDB system collections 

### DIFF
--- a/lib/database_cleaner/mongo/truncation.rb
+++ b/lib/database_cleaner/mongo/truncation.rb
@@ -14,7 +14,7 @@ module DatabaseCleaner
       private
 
       def collections
-        database.collections.select { |c| c.name !~ /^system/ }
+        database.collections.select { |c| c.name !~ /^system\./ }
       end
 
     end


### PR DESCRIPTION
As described here http://www.mongodb.org/display/DOCS/Mongo+Metadata MongoDb system collections starts with 'system.' <-- notice the dot at the end, not just with 'system'.

This is important becouse when I have 'system_admins' collection in my database it is not truncated. :(

So here is a fix for that case.
