### PR TITLE
reset sequences when truncating (postgresql)

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -70,8 +70,12 @@ module ActiveRecord
         @cascade ||= db_version >=  "08.02" ? "CASCADE" : ""
       end
 
+      def restart_identity
+        @restart_identity ||= db_version >=  "08.04" ? "RESTART IDENTITY" : ""
+      end
+
       def truncate_table(table_name)
-        execute("TRUNCATE TABLE #{quote_table_name(table_name)} RESTART IDENTITY #{cascade};")
+        execute("TRUNCATE TABLE #{quote_table_name(table_name)} #{restart_identity} #{cascade};")
       end
 
     end


### PR DESCRIPTION
This solves the following issue:  when truncating in postgresql, the sequences are not reset.

If you have a test that depends on records getting specific ids when created, the test could fail.
