### PR TITLE
Fix AR transactions in the presence of a connection hash

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -42,10 +42,15 @@ module DatabaseCleaner
       end
 
       def connection_klass
-        return ::ActiveRecord::Base if connection_hash.nil?
-        klass = create_connection_klass
-        klass.send :establish_connection, connection_hash
-        klass
+        @connection_klass ||= begin
+          if connection_hash.nil?
+            ::ActiveRecord::Base
+          else
+            klass = create_connection_klass
+            klass.send :establish_connection, connection_hash
+            klass
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Before this patch, calling #connection_klass in the transaction strategy would keep creating new connections upon every invocation. AR would blow up when decrementing the transaction count because this was being done on a brand new class each time.
