### PR TITLE
Don't modify list of table names to except from truncation

### DIFF
--- a/lib/database_cleaner/generic/truncation.rb
+++ b/lib/database_cleaner/generic/truncation.rb
@@ -15,7 +15,7 @@ module DatabaseCleaner
           end
 
           @only = opts[:only]
-          @tables_to_exclude = (opts[:except] || [])
+          @tables_to_exclude = (opts[:except] || []).dup
           @tables_to_exclude << migration_storage_name unless migration_storage_name.nil?
         end
 

--- a/spec/database_cleaner/generic/truncation_spec.rb
+++ b/spec/database_cleaner/generic/truncation_spec.rb
@@ -62,6 +62,16 @@ module ::DatabaseCleaner
           its(:only)   { should == nil }
           its(:except) { should == ["migration_storage_name"] }
         end
+
+        context "" do
+          EXCEPT_TABLES = ["something"]
+          subject { MigrationExample.new( { :except => EXCEPT_TABLES } ) }
+
+          it "should not modify the array of excepted tables" do
+            subject.except.should include("migration_storage_name")
+            EXCEPT_TABLES.should_not include("migration_storage_name")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The array passed does not belong to us, and so we should dup it before we modify it (via append in this case).
