### PR TITLE
postgresql version checking

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -60,15 +60,15 @@ module ActiveRecord
     class PostgreSQLAdapter < AbstractAdapter
 
       def db_version
-        @db_version ||= select_value('SHOW SERVER_VERSION')
+        @db_version ||= postgresql_version
       end
 
       def cascade
-        @cascade ||= db_version >=  '8.2' ? 'CASCADE' : ''
+        @cascade ||= db_version >=  80200 ? 'CASCADE' : ''
       end
 
       def restart_identity
-        @restart_identity ||= db_version >=  '8.4' ? 'RESTART IDENTITY' : ''
+        @restart_identity ||= db_version >=  80400 ? 'RESTART IDENTITY' : ''
       end
 
       def truncate_table(table_name)


### PR DESCRIPTION
The first commit works, for versions of postgresql up to 9.*

The second should work for any and all future versions of postgresql, as long as the implementation of postgresql_version in ActiveRecord doesn't change...
