### PR TITLE
DataMapper 1.1 removes String#compress_lines

### DIFF
--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -42,7 +42,7 @@ module DataMapper
       # taken from http://github.com/godfat/dm-mapping/tree/master
       def storage_names(repository = :default)
         # activerecord-2.1.0/lib/active_record/connection_adapters/sqlite_adapter.rb: 177
-        sql = <<-SQL.compress_lines
+        sql = <<-SQL
           SELECT name
           FROM sqlite_master
           WHERE type = 'table' AND NOT name = 'sqlite_sequence'
@@ -68,7 +68,7 @@ module DataMapper
       # taken from http://github.com/godfat/dm-mapping/tree/master
       def storage_names(repository = :default)
         # activerecord-2.1.0/lib/active_record/connection_adapters/sqlite_adapter.rb: 177
-        sql = <<-SQL.compress_lines
+        sql = <<-SQL
           SELECT name
           FROM sqlite_master
           WHERE type = 'table' AND NOT name = 'sqlite_sequence'
@@ -99,7 +99,7 @@ module DataMapper
 
       # taken from http://github.com/godfat/dm-mapping/tree/master
       def storage_names(repository = :default)
-        sql = <<-SQL.compress_lines
+        sql = <<-SQL
           SELECT table_name FROM "information_schema"."tables"
           WHERE table_schema = current_schema() and table_type = 'BASE TABLE'
         SQL


### PR DESCRIPTION
The DataMapper 1.1 release candidates remove String#compress_lines (see [datamapper/dm-core [43cc1055]](https://github.com/datamapper/dm-core/commit/43cc1055)). This causes database_cleaner to fail when using the latest DM versions.

Since it isn't needed when executing queries, I've removed it from the DM strategies.
