### PR TITLE
Cache the connection we use to clean the DB with 

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -53,10 +53,8 @@ module DatabaseCleaner::ActiveRecord
   class Deletion < Truncation
 
     def clean
-      connection.disable_referential_integrity do
-        tables_to_truncate.each do |table_name|
-          connection.delete_table table_name
-        end
+      each_table do |connection, table_name|
+        connection.delete_table table_name
       end
     end
 

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -103,22 +103,24 @@ module DatabaseCleaner::ActiveRecord
     include ::DatabaseCleaner::Generic::Truncation
 
     def clean
+      each_table do |connection, table_name|
+        connection.truncate_table table_name
+      end
+    end
+
+    def each_table
+      connection = connection_klass.connection
       connection.disable_referential_integrity do
-        tables_to_truncate.each do |table_name|
-          connection.truncate_table table_name
+        tables_to_truncate(connection).each do |table_name|
+          yield connection, table_name
         end
       end
     end
 
     private
 
-    def tables_to_truncate
+    def tables_to_truncate(connection)
        (@only || connection.tables) - @tables_to_exclude - connection.views
-    end
-
-    def connection
-       #::ActiveRecord::Base.connection
-       @connection ||= connection_klass.connection
     end
 
     # overwritten


### PR DESCRIPTION
Due to pools etc eveything we called connection_klass.connection we would get a different connection. I hit a bug using multiple DBs where eventually the connection that did the referential integrity would not exist any more and then everything would fail when it tried to reset the foreign keys.
