### PR TITLE
Fixed regression in AR deletion strategy

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -53,7 +53,8 @@ module DatabaseCleaner::ActiveRecord
   class Deletion < Truncation
 
     def clean
-      each_table do |connection, table_name|
+      connection = connection_klass.connection
+      tables_to_truncate(connection).each do |table_name|
         connection.delete_table table_name
       end
     end


### PR DESCRIPTION
Hi,

I just noticed that the AR deletion strategy stopped working because the each_table method has been removed from the Truncation strategy. This tiny commit fixes the regression.

Thanks
