### PR TITLE
Truncation should reset a table's id column

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -53,6 +53,7 @@ module ActiveRecord
     class SQLite3Adapter < SQLITE_ADAPTER_PARENT
       def delete_table(table_name)
         execute("DELETE FROM #{quote_table_name(table_name)};")
+        execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
       end
       alias truncate_table delete_table
     end

--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -53,6 +53,7 @@ module DataMapper
 
       def truncate_table(table_name)
         execute("DELETE FROM #{quote_name(table_name)};")
+        execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
       end
 
       # this is a no-op copied from activerecord
@@ -79,6 +80,7 @@ module DataMapper
 
       def truncate_table(table_name)
         execute("DELETE FROM #{quote_name(table_name)};")
+        execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
       end
 
       # this is a no-op copied from activerecord
@@ -107,7 +109,7 @@ module DataMapper
       end
 
       def truncate_table(table_name)
-        execute("TRUNCATE TABLE #{quote_name(table_name)} CASCADE;")
+        execute("TRUNCATE TABLE #{quote_name(table_name)} RESTART IDENTITY CASCADE;")
       end
 
       # FIXME


### PR DESCRIPTION
Per issue #66, this patch brings consistency to the Truncation strategy, in terms of the state that a table's id column is left in after a cleaning. With this change, any db's table id columns should be reset to 0 after truncation. This is the default behavior of TRUNCATE for Oracle, IBM, MSSQL, and MySQL. This commit merely mimics that behavior for SQLite and Postgres.

I don't know enough about the NoSQL dbs to guess if or how this should apply to them.
