### PR TITLE
Rails 3.2 rc1 gives error "superclass mismatch for class Mysql2Adapter (TypeError)"

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       end
     end
 
-    class Mysql2Adapter < AbstractAdapter
+    class Mysql2Adapter < AbstractMysqlAdapter
       def truncate_table(table_name)
         execute("TRUNCATE TABLE #{quote_table_name(table_name)};")
       end


### PR DESCRIPTION
Hi!

Was trying to run my specs on Rails 3.2 rc1 and I got the above error. 

This patch seems to fix the error.

Cheers,
Aditya
