### PR TITLE
Fixed superclass mismatch error on ActiveRecord 3.2 RC

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -29,7 +29,15 @@ module ActiveRecord
       end
     end
 
-    MYSQL_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
+    # ActiveRecord 3.1 support
+    if defined?(AbstractMysqlAdapter)
+      MYSQL_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractMysqlAdapter
+      MYSQL2_ADAPTER_PARENT = AbstractMysqlAdapter
+    else
+      MYSQL_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
+      MYSQL2_ADAPTER_PARENT = AbstractAdapter
+    end
+    
     SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : SQLiteAdapter
     POSTGRE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
 
@@ -39,7 +47,7 @@ module ActiveRecord
       end
     end
 
-    class Mysql2Adapter < AbstractAdapter
+    class Mysql2Adapter < MYSQL2_ADAPTER_PARENT
       def truncate_table(table_name)
         execute("TRUNCATE TABLE #{quote_table_name(table_name)};")
       end


### PR DESCRIPTION
DatabaseCleaner's Truncation strategy is implemented by patching some code in various ActiveRecord connection adapters. While the connection adapter architecture has been more or less stable since Rails 2.3, the upcoming 3.2 release attempts to share some behavior between the Mysql and Mysql2 adapters by adding a new abstract superclass, AbstractMysqlAdapter. Long story short, using DatabaseCleaner on Rails 3.2 causes applications to crash while booting. This works around the issue by checking for the existence of AbstractMysqlAdapter and using it for MySQL engines if present, falling back to AbstractAdapter if it's not present.
