### PR TITLE
Fix Mysql2Adapter superclass.

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       end
     end
 
-    class Mysql2Adapter < AbstractAdapter
+    class Mysql2Adapter < MYSQL2_ADAPTER_PARENT
       def delete_table(table_name)
         execute("DELETE FROM #{quote_table_name(table_name)};")
       end


### PR DESCRIPTION
Is there any reason not to use `class_eval`? that would save having to know the exact superclass.
