### PR TITLE
notification of create transaction strategy with options.

### DIFF
--- a/lib/database_cleaner/active_record/transaction.rb
+++ b/lib/database_cleaner/active_record/transaction.rb
@@ -1,7 +1,10 @@
 require 'database_cleaner/active_record/base'
+require 'database_cleaner/generic/transaction'
+
 module DatabaseCleaner::ActiveRecord
   class Transaction
     include ::DatabaseCleaner::ActiveRecord::Base
+    include ::DatabaseCleaner::Generic::Transaction
 
     def start
       if connection_klass.connection.respond_to?(:increment_open_transactions)

--- a/lib/database_cleaner/data_mapper/transaction.rb
+++ b/lib/database_cleaner/data_mapper/transaction.rb
@@ -1,8 +1,10 @@
 require 'database_cleaner/data_mapper/base'
+require 'database_cleaner/generic/transaction'
 
 module DatabaseCleaner::DataMapper
   class Transaction
     include ::DatabaseCleaner::DataMapper::Base
+    include ::DatabaseCleaner::Generic::Transaction
 
     def start(repository = self.db)
       ::DataMapper.repository(repository) do |r|

--- a/lib/database_cleaner/generic/transaction.rb
+++ b/lib/database_cleaner/generic/transaction.rb
@@ -1,0 +1,11 @@
+module DatabaseCleaner
+  module Generic
+    module Transaction
+      def initialize(opts = {})
+        if !opts.empty?
+          raise ArgumentError, "Options are not available for transaction strategies."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi

I was mistakenly given transaction strategy to options, like a truncation strategy. so DatabaseCleaner ignore the creating for transaction strategy with options.

this mistake is cause to pure ruby ArgumentError when running Ruby-1.9.3 later. At first, I don't know where the error was. this pull request is a warning to transaction can not use the options.
