### PR TITLE
Transaction strategy works with ActiveRecord and multiple databases

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -44,6 +44,14 @@ module DatabaseCleaner
 
       def connection_klass
         return ::ActiveRecord::Base unless connection_hash
+
+        if ::ActiveRecord::Base.respond_to?(:descendants)
+          database_name = connection_hash["database"]
+          models = ::ActiveRecord::Base.descendants
+          klass = models.detect {|m| m.connection_pool.spec.config[:database] == database_name}
+          return klass if klass
+        end
+
         klass = create_connection_klass
         klass.send :establish_connection, connection_hash
         klass


### PR DESCRIPTION
It works with rails 3 and should not crash rails 2.3.

I would love to test it but could not setup testing environment correctly. I tried with the environment from .rvmrc but it does not work as project uses ruby 1.9 hashes syntax at lib/database_cleaner/sequel/transaction.rb.

With ruby 1.9 I could not install whole bundle as it depends on a gem not ready for ruby 1.9.

Please, let me know how to run testcase. I am probably missing something...
