### PR TITLE
Postgresql truncation no table fix

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -96,6 +96,7 @@ module ActiveRecord
       end
       
       def truncate_tables(table_names)
+        return if table_names.nil? || table_names.empty?
         execute("TRUNCATE TABLE #{table_names.map{|name| quote_table_name(name)}.join(', ')} #{restart_identity} #{cascade};")
       end
 


### PR DESCRIPTION
This patch fixes a small bug in the pg truncation adapter. All adapters except pg rely on the `#truncate_tables` method defined in `AbstractAdapter` to iterate through all the tables and truncate each one.

``` ruby
      def truncate_tables(tables)
        tables.each do |table_name|
          self.truncate_table(table_name)
        end
      end
```

If no tables are supplied then no tables can be truncated. The pg adapter defines its own `#truncate_tables` method which doesn't account for an empty list of tables. In the patch I'm simply checking that `tables` is neither nil nor empty before executing the `TRUNCATE TABLE` statement.
