### PR TITLE
Added docs about dm-transactions dependency

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -29,6 +29,12 @@ with any ORM library. You can also explicitly use it by setting your strategy to
 
 For support or to discuss development please use the "Google Group":http://groups.google.com/group/database_cleaner.
 
+h2. Dependencies
+
+Because database_cleaner supports multiple ORMs, it doesn't make sense to include all the dependencies
+for each one in the gemspec.  However, the DataMapper adapter does depend on dm-transactions.  Therefore,
+if you use DataMapper, you must include dm-transactions in your Gemfile/bundle/gemset manually.  
+
 h2. How to use
 
 <pre>


### PR DESCRIPTION
I don't know for  sure this is correct, but it seems that database_cleaner depends on dm-transactions when using DataMapper, but it's not included in the gemspec.  I've added a section to the readme on dependencies to clarify this for new users.

If there are other dependencies for other ORMs, this might be a good place for another table :)

Let me know if anything here is incorrect.
