### PR TITLE
Use a single statement for DataMapper truncation on PostgreSQL

### DIFF
--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -10,6 +10,12 @@ module DataMapper
         raise NotImplementedError
       end
 
+      def truncate_tables(table_names)
+        table_names.each do |table_name|
+          adapter.truncate_table table_name
+        end
+      end
+
     end
 
     class MysqlAdapter < DataObjectsAdapter
@@ -112,6 +118,12 @@ module DataMapper
         execute("TRUNCATE TABLE #{quote_name(table_name)} RESTART IDENTITY CASCADE;")
       end
 
+      # override to use a single statement
+      def truncate_tables(table_names)
+        quoted_names = table_names.collect { |n| quote_name(n) }.join(', ')
+        execute("TRUNCATE TABLE #{quoted_names} RESTART IDENTITY;")
+      end
+
       # FIXME
       # copied from activerecord
       def supports_disable_referential_integrity?
@@ -153,9 +165,7 @@ module DatabaseCleaner
       def clean(repository = self.db)
         adapter = ::DataMapper.repository(repository).adapter
         adapter.disable_referential_integrity do
-          tables_to_truncate(repository).each do |table_name|
-            adapter.truncate_table table_name
-          end
+          adapter.truncate_tables(tables_to_truncate(repository))
         end
       end
 


### PR DESCRIPTION
This change aligns the behavior of the DM PostgreSQL truncation adapter with
the ActiveRecord one. A single statement is faster and safer than lots of
`TRUNCATE TABLE ... CASCADE` statements.

While this commit only implements single statements for PostgreSQL, it
provides the extension point necessary for other adapters to switch to single
statements in the future.
