### PR TITLE
Fix support for newer Sequel versions

### DIFF
--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -8,7 +8,7 @@ module DatabaseCleaner
       include ::DatabaseCleaner::Generic::Truncation
   
       def clean
-        case db_type= db.url.sub(/:.+/,'').to_sym
+        case db.database_type
         when :postgres
           # PostgreSQL requires all tables with FKs to be truncates in the same command, or have the CASCADE keyword
           # appended. Bulk truncation without CASCADE is:


### PR DESCRIPTION
Also, there is another catch, I'm not sure how to deal with.

First, I guess the documentation is wrong:

``` plain
DatabaseCleaner.strategy = :truncation, {:except => %w[widgets]}
```

Should be:

``` plain
DatabaseCleaner.strategy = [:truncation, {:except => %w[widgets]}]
```

But for this to work in Sequel, the tables must be passed as symbols. This is how I use it:

``` plain
DatabaseCleaner.strategy = [:truncation, except: [:schema_migrations, :roles]]
```

Sequel will also exclude :schema_info, although I don't use it for keeping track of database changes as I'm using standalone_migrations. This is not a major issue as I don't even have this table, but it could be if that table had a different mean for my application.

I'm only sending a simple patch because I'm not sure how to deal with the other issues.
