### PR TITLE
db.url can be nil if Sequel.connect(HASH) was used

### DIFF
--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -8,7 +8,7 @@ module DatabaseCleaner
       include ::DatabaseCleaner::Generic::Truncation
   
       def clean
-        case db_type= db.url.sub(/:.+/,'').to_sym
+        case db_type= db.adapter_scheme
         when :postgres
           # PostgreSQL requires all tables with FKs to be truncates in the same command, or have the CASCADE keyword
           # appended. Bulk truncation without CASCADE is:


### PR DESCRIPTION
db.url/db.uri is not set if a hash is used to connect to the database, but database_type is always set and returns the correct type.

http://sequel.rubyforge.org/rdoc/classes/Sequel/Dataset.html
