### PR TITLE
Multiple Sequel Databases without a database.yml 

### DIFF
--- a/spec/database_cleaner/configuration_spec.rb
+++ b/spec/database_cleaner/configuration_spec.rb
@@ -232,6 +232,32 @@ describe ::DatabaseCleaner do
         ::DatabaseCleaner.connections.size.should == 1
       end
     end
+
+    # this context illustrates bug found here: https://groups.google.com/forum/?fromgroups#!topic/database_cleaner/uQDsWXV-_8I
+    context "single orm with multiple connections" do
+
+      let(:sequel) { mock("sequel_mock") }
+
+      it "should close multiple connections (sequel)" do
+        require "sequel"
+
+        db_one = Sequel.Mock.Connection.new
+        db_two = Sequel.Mock.Connection.new
+
+        ::DatabaseCleaner[:sequel, {:connection => db_one}].strategy = :truncation
+        ::DatabaseCleaner[:sequel, {:connection => db_one}].clean_with(:truncation)
+
+        ::DatabaseCleaner[:sequel, {:connection => db_two}].strategy = :truncation
+        ::DatabaseCleaner[:sequel, {:connection => db_two}].clean_with(:truncation)
+
+        ::DatabaseCleaner[:sequel, {:connection => db_one}].start
+        ::DatabaseCleaner[:sequel, {:connection => db_two}].start
+
+        lambda { ::DatabaseCleaner[:sequel, {:connection => db_one}].stop }.should_not raise_error
+        lambda { ::DatabaseCleaner[:sequel, {:connection => db_two}].stop }.should_not raise_error
+        
+      end
+    end
   end
 
   describe "remove_duplicates" do


### PR DESCRIPTION
Hi,
I post a bug on Google Groups and the your suggested work-around did not work.
I tried to investigate the bug on my own, but I had a lot of trouble getting the environment set up.
OS X Lion and ruby 1.8.7 + a few of the gem with native bindings cause issues do not work well together. This might be the cause of the bug in the first place; I discovered the bug using ruby 1.9.3 
Anyhow, I added a spec which should catch the bug. 

I wish I could be of more help. If I have more time, I will investigate using a VM. 

Cheers!
-T

BUG:  https://groups.google.com/forum/?fromgroups#!topic/database_cleaner/uQDsWXV-_8I

NOTE: not sure is this code runs as I was unable to get the environment set up.
      OS X Lion and ruby 1.8.7 + a few of the gem with native bindings cause issues.
      This might be the cause of the bug in the first place.
