### PR TITLE
Active record truncation table cache

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,7 @@
 == 0.8.x (in git)
 
+  * view caching works with the schema_plus gem loaded
+    * ActiveRecord::ConnectionAdapters::AbstractAdapter#views was renamed to an internal name
   * ActiveRecord truncation strategy caches the list of tables #130 (Petteri Räty)
 
 == 0.8.0 2012-06-02

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -9,7 +9,9 @@ module ActiveRecord
     USE_ARJDBC_WORKAROUND = defined?(ArJdbc)
 
     class AbstractAdapter
-      def views
+      # used to be called views but that can clash with gems like schema_plus
+      # this gem is not meant to be exposing such an extra interface any way
+      def database_cleaner_view_cache
         @views ||= select_values("select table_name from information_schema.views where table_schema = '#{current_database}'") rescue []
       end
 
@@ -142,7 +144,7 @@ module DatabaseCleaner::ActiveRecord
     private
 
     def tables_to_truncate(connection)
-      (@only || connection.database_cleaner_table_cache) - @tables_to_exclude - connection.views
+      (@only || connection.database_cleaner_table_cache) - @tables_to_exclude - connection.database_cleaner_view_cache
     end
 
     # overwritten

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -25,7 +25,7 @@ module DatabaseCleaner
 
       before(:each) do
         connection.stub!(:disable_referential_integrity).and_yield
-        connection.stub!(:views).and_return([])
+        connection.stub!(:database_cleaner_view_cache).and_return([])
         ::ActiveRecord::Base.stub!(:connection).and_return(connection)
       end
 
@@ -64,7 +64,7 @@ module DatabaseCleaner
 
       it "should not truncate views" do
         connection.stub!(:database_cleaner_table_cache).and_return(%w[widgets dogs])
-        connection.stub!(:views).and_return(["widgets"])
+        connection.stub!(:database_cleaner_view_cache).and_return(["widgets"])
 
         connection.should_receive(:truncate_tables).with(['dogs'])
 


### PR DESCRIPTION
With these two commits my rails application didn't issue schema query statements for DatabaseCleaner.clean_with :truncation for console in RAILS_ENV=test
