### PR TITLE
enables the deletion strategy also to JRuby (and not only the truncation strategy)

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       end
     end
 
-    class PostgreSQLAdapter < AbstractAdapter
+    class PostgreSQLAdapter < POSTGRE_ADAPTER_PARENT
       def delete_table(table_name)
         execute("DELETE FROM #{quote_table_name(table_name)};")
       end


### PR DESCRIPTION
This fix makes also the deletion strategy available to JRuby and not only the truncation strategy (this was already fixed in 0.7.1)
