### PR TITLE
Actually rescue a LoadError when the AR mysql adapters are not available.

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -2,7 +2,10 @@ require 'active_record/base'
 
 require 'active_record/connection_adapters/abstract_adapter'
 
-require 'active_record/connection_adapters/abstract_mysql_adapter' rescue LoadError
+begin
+  require 'active_record/connection_adapters/abstract_mysql_adapter'
+rescue LoadError
+end
 
 require "database_cleaner/generic/truncation"
 require 'database_cleaner/active_record/base'


### PR DESCRIPTION
This fix ensures that LoadErrors will be rescued correctly for require.

I was getting the following error when attempting to run specs, using master (016d66c4c962)

```
 /home/garrowb/.rvm/gems/ruby-1.8.7-p370/bundler/gems/database_cleaner-016d66c4c962/lib/database_cleaner/base.rb:104:in `orm_strategy': 
 The 'truncation' strategy does not exist for the active_record ORM!  
  Available strategies: truncation, transaction, deletion (DatabaseCleaner::UnknownStrategySpecified)
```

After some prodding and poking I found this error was due to a LoadError not being caught correctly.

```
 no such file to load -- active_record/connection_adapters/abstract_mysql_adapter
```

Which was due to this commit, https://github.com/bmabey/database_cleaner/commit/20963dd75bc9a2222e6c3645b39c1096d4c4b2a8#L0L5

I could reproduce the same sort of error in IRB using MRI 1.8.7.

```
◇1.8.7 ± irb
1.8.7 :001 > def berk
1.8.7 :002?>   require 'missing_thing' rescue LoadError
1.8.7 :003?>   end
 => nil 
1.8.7 :004 > def yay
1.8.7 :005?>   require 'another_missing_thing' 
1.8.7 :006?>   rescue LoadError
1.8.7 :007?>   end
 => nil 
1.8.7 :008 > berk
LoadError: no such file to load -- missing_thing
    from (irb):2:in `require'
    from (irb):2:in `berk'
    from (irb):8
1.8.7 :009 > yay
 => nil 
```

The underlying problem is this [rejected] Ruby bug -  https://bugs.ruby-lang.org/issues/6202 - where the reason was. "'rescue' modifier and 'rescue' clause with no exception classes catch only StandardError and its subclasses.
LoadError can't be caught. "
