### PR TITLE
Sequel also uses schema_migrations as a migration table

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -12,7 +12,7 @@ require 'database_cleaner/active_record/base'
 
 module DatabaseCleaner
   module ActiveRecord
-      
+
     module AbstractAdapter
       # used to be called views but that can clash with gems like schema_plus
       # this gem is not meant to be exposing such an extra interface any way
@@ -37,7 +37,7 @@ module DatabaseCleaner
     end
 
     module MysqlAdapter
-      
+
       def truncate_table(table_name)
         execute("TRUNCATE TABLE #{quote_table_name(table_name)};")
       end
@@ -53,7 +53,7 @@ module DatabaseCleaner
 
       private
 
-      
+
       def row_count(table)
         select_value("SELECT EXISTS (SELECT 1 FROM #{quote_table_name(table)} LIMIT 1)")
       end
@@ -67,8 +67,8 @@ module DatabaseCleaner
           true
         else
           select_value(<<-SQL) > 1 # returns nil if not present
-              SELECT Auto_increment 
-              FROM information_schema.tables 
+              SELECT Auto_increment
+              FROM information_schema.tables
               WHERE table_name='#{table}';
           SQL
         end
@@ -79,14 +79,14 @@ module DatabaseCleaner
       end
     end
 
-    
+
     module IBM_DBAdapter
       def truncate_table(table_name)
         execute("TRUNCATE #{quote_table_name(table_name)} IMMEDIATE")
       end
     end
 
-    
+
     module SQLiteAdapter
       def delete_table(table_name)
         execute("DELETE FROM #{quote_table_name(table_name)};")
@@ -181,7 +181,7 @@ module ActiveRecord
       MYSQL_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
       MYSQL2_ADAPTER_PARENT = AbstractAdapter
     end
-    
+
     SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : SQLiteAdapter
     POSTGRE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
 
@@ -244,8 +244,8 @@ module DatabaseCleaner::ActiveRecord
     end
 
     # overwritten
-    def migration_storage_name
-      'schema_migrations'
+    def migration_storage_names
+      %w[schema_migrations]
     end
 
     def pre_count?

--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -167,7 +167,7 @@ module DatabaseCleaner
 
       # overwritten
       def migration_storage_name
-        'migration_info'
+        %w[migration_info]
       end
 
     end

--- a/lib/database_cleaner/generic/truncation.rb
+++ b/lib/database_cleaner/generic/truncation.rb
@@ -31,8 +31,8 @@ module DatabaseCleaner
 
       # overwrite in subclasses
       # default implementation given because migration storage need not be present
-      def migration_storage_name
-        nil
+      def migration_storage_names
+        %w[]
       end
     end
   end

--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -6,7 +6,7 @@ module DatabaseCleaner
     class Truncation
       include ::DatabaseCleaner::Sequel::Base
       include ::DatabaseCleaner::Generic::Truncation
-  
+
       def clean
         case db.database_type
         when :postgres
@@ -25,7 +25,7 @@ module DatabaseCleaner
           end
         end
       end
-  
+
       def each_table
         tables_to_truncate(db).each do |table|
           yield db, table
@@ -33,14 +33,14 @@ module DatabaseCleaner
       end
 
       private
-  
+
       def tables_to_truncate(db)
         (@only || db.tables) - @tables_to_exclude
       end
 
       # overwritten
-      def migration_storage_name
-        :schema_info
+      def migration_storage_names
+        %w[schema_info schema_migrations]
       end
 
     end

--- a/spec/database_cleaner/generic/truncation_spec.rb
+++ b/spec/database_cleaner/generic/truncation_spec.rb
@@ -24,8 +24,8 @@ module ::DatabaseCleaner
     end
 
     class MigrationExample < TruncationExample
-      def migration_storage_name
-        "migration_storage_name"
+      def migration_storage_names
+        %w[migration_storage_name]
       end
     end
 
@@ -37,8 +37,8 @@ module ::DatabaseCleaner
         it { should_not respond_to(:tables_to_truncate) }
         its(:tables_to_truncate) { expect{ subject }.to raise_error(NotImplementedError) }
 
-        it { should_not respond_to(:migration_storage_name) }
-        its(:migration_storage_name) { should be_nil }
+        it { should_not respond_to(:migration_storage_names) }
+        its(:migration_storage_names) { should be_empty }
       end
 
       describe "initialize" do
@@ -86,11 +86,11 @@ module ::DatabaseCleaner
           subject { TruncationExample.new( { :pre_count => nil } ) }
           its(:pre_count?) { should == false }
         end
-        
+
         context "" do
           subject { MigrationExample.new }
           its(:only)   { should == nil }
-          its(:except) { should == ["migration_storage_name"] }
+          its(:except) { should == %w[migration_storage_name] }
         end
 
         context "" do


### PR DESCRIPTION
Currently the sequel adapter uses `schema_info` as the migration table, but sequel also uses `schema_migrations` as the migration table if you use a timestamp based migration naming convention (vs the integer based).

For now, the solution is:

``` ruby
DatabaseCleaner.strategy = :truncation, { except: [:schema_migrations] }
```
