### PR TITLE
change in README Common Errors / STDERR is being flooded when using Postgres

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -226,7 +226,15 @@ DatabaseCleaner has an autodetect mechanism where if you do not explicitly defin
 h4. STDERR is being flooded when using Postgres
 
 If you are using Postgres and have foreign key constraints, the truncation strategy will cause a lot of extra noise to appear on STDERR (in
-the form of "NOTICE truncate cascades" messages). To silence these warnings set the following log level in your database.yml file:
+the form of "NOTICE truncate cascades" messages). 
+
+To silence these warnings set the following log level in your postgresql.conf file:
+
+<pre>
+  client_min_messages = warning
+</pre>
+
+For ActiveRecord, you add the following parameter in your database.yml file:
 
 <pre>
 test:
@@ -234,7 +242,6 @@ test:
   # ...
   min_messages: WARNING  
 </pre>
-
 
 h2. Debugging
 


### PR DESCRIPTION
In order to reduce noise in STDERR, it's easier to tweak database.yml
