### PR TITLE
Use correct SQLite3Adapter superclass in Rails 4

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -182,7 +182,11 @@ module ActiveRecord
       MYSQL2_ADAPTER_PARENT = AbstractAdapter
     end
 
-    SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : SQLiteAdapter
+    if defined?(SQLite3Adapter) && SQLite3Adapter.superclass == ActiveRecord::ConnectionAdapters::AbstractAdapter
+      SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
+    else
+      SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : SQLiteAdapter
+    end
     POSTGRE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
 
     class MysqlAdapter < MYSQL_ADAPTER_PARENT


### PR DESCRIPTION
Hi there.

I'm using Database Cleaner in a Rails 4 (edge) project, and the current master fails with:

.../database_cleaner-0.9.1/lib/database_cleaner/active_record/truncation.rb:200:in `module:ConnectionAdapters': superclass mismatch for class SQLite3Adapter (TypeError)

Looks like the SQLite3Adapter superclass changed in Rails 4. This commit checks the superclass in truncation.rb and should preserver Rails 3 compatibility.
