### PR TITLE
Sequel returns table names as symbols, DatabaseCleaner expects strings

### DIFF
--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -35,7 +35,7 @@ module DatabaseCleaner
       private
 
       def tables_to_truncate(db)
-        (@only || db.tables) - @tables_to_exclude
+        (@only || db.tables.map(&:to_s)) - @tables_to_exclude
       end
 
       # overwritten


### PR DESCRIPTION
This was mentioned in #120.

When using Sequel and truncation, the `:except` option doesn't work. This is because `db.tables` returns an array of symbols but the tables to be excluded by default are strings, and the documentation also tells you to use strings. I think you should either:
1. Change the table names that are excluded by default to symbols and mention in the documentation that with Sequel you should you symbols.
2. Map the table names to strings.

This patch does option 2. although I'm not sure if that's the best way.
