### PR TITLE
Bugfix to ActiveRecord PostgreSQLAdapter pre_count

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -139,8 +139,8 @@ module DatabaseCleaner
       # but then the table is cleaned.  In other words, this function tells us if the given table
       # was ever inserted into.
       def has_been_used?(table)
-        cur_val = select_value("SELECT currval('#{table}_id_seq');").to_i rescue ActiveRecord::StatementInvalid
-        cur_val && cur_val > 0
+        cur_val = select_value("SELECT currval('#{table}_id_seq');").to_i rescue 0
+        cur_val > 0
       end
 
       def has_rows?(table)


### PR DESCRIPTION
Loving the addition of `:pre_count`. But after I enabled it (using database_cleaner 0.9.1, ActiveRecord 3.1.4, and Postgres 9.1) all my tests started failing with `uninitialized constant DatabaseCleaner::ActiveRecord::StatementInvalid`.

I found the offending namespace/scope issue and tried fixing it using `::ActiveRecord::StatementInvalid`. That fixed it but caused a syntax error. Then I saw the obvious bug and came up with this patch. It was probably just a brain fart while someone was refactoring. Sure, `::ActiveRecord::StatementInvalid` is the exception we're catching, but it's certainly not the value we want to set.

P.S. I noticed that `:pre_count` won't necessarily truncate all tables with data in them (at least Postgres's implementation won't - I haven't looked at the others.) Some of my fixtures define the record id. In those cases, Postgres's `nextval` isn't called, meaning that `currval` won't return anything, meaning they will be skipped by `:pre_count` (at least I'm pretty sure that's why...). AFAIK that's not a problem in most cases, but it's worth noting, and I didn't see it mentioned anywhere.
