### PR TITLE
Fix Travis builds – add MongoDB service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ before_script:
   - mysql -e 'create database database_cleaner_test;'
   - psql -c 'create database database_cleaner_test;' -U postgres
   - cp db/sample.config.yml db/config.yml
+services:
+  - mongodb


### PR DESCRIPTION
I've noticed that the failing tests were for Mongoid due to `ConnectionFailure`, so here's a quick fix for Travis CI.
