### PR TITLE
Fixed SQLite truncation error "no such table: sqlite_sequence"

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -90,9 +90,18 @@ module DatabaseCleaner
     module SQLiteAdapter
       def delete_table(table_name)
         execute("DELETE FROM #{quote_table_name(table_name)};")
-        execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
+        if uses_sequence
+          execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
+        end
       end
       alias truncate_table delete_table
+
+      private
+
+      # Returns a boolean indicating if the SQLite database is using the sqlite_sequence table.
+      def uses_sequence
+        select_value("SELECT name FROM sqlite_master WHERE type='table' AND name='sqlite_sequence';")
+      end
     end
 
     module TruncateOrDelete

--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -53,7 +53,9 @@ module DataMapper
 
       def truncate_table(table_name)
         execute("DELETE FROM #{quote_name(table_name)};")
-        execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
+        if uses_sequence
+          execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
+        end
       end
 
       # this is a no-op copied from activerecord
@@ -80,7 +82,9 @@ module DataMapper
 
       def truncate_table(table_name)
         execute("DELETE FROM #{quote_name(table_name)};")
-        execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
+        if uses_sequence
+          execute("DELETE FROM sqlite_sequence where name = '#{table_name}';")
+        end
       end
 
       # this is a no-op copied from activerecord


### PR DESCRIPTION
SQLite truncation assumes the `sqlite_sequence` table exists and fails if it does not. Added private function `uses_sequence` to make sure the table exists first.
