### PR TITLE
One network trip for the deletion strategy

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -3,51 +3,6 @@ require 'active_record/connection_adapters/abstract_adapter'
 require "database_cleaner/generic/truncation"
 require 'database_cleaner/active_record/base'
 require 'database_cleaner/active_record/truncation'
-# This file may seem to have duplication with that of truncation, but by keeping them separate
-# we avoiding loading this code when it is not being used (which is the common case).
-
-module ActiveRecord
-  module ConnectionAdapters
-
-    class MysqlAdapter < MYSQL_ADAPTER_PARENT
-      def delete_table(table_name)
-        execute("DELETE FROM #{quote_table_name(table_name)};")
-      end
-    end
-
-    class Mysql2Adapter < MYSQL2_ADAPTER_PARENT
-      def delete_table(table_name)
-        execute("DELETE FROM #{quote_table_name(table_name)};")
-      end
-    end
-
-    class JdbcAdapter < AbstractAdapter
-      def delete_table(table_name)
-          execute("DELETE FROM #{quote_table_name(table_name)};")
-      end
-    end
-
-    class PostgreSQLAdapter < POSTGRE_ADAPTER_PARENT
-      def delete_table(table_name)
-        execute("DELETE FROM #{quote_table_name(table_name)};")
-      end
-    end
-
-    class SQLServerAdapter < AbstractAdapter
-      def delete_table(table_name)
-        execute("DELETE FROM #{quote_table_name(table_name)};")
-      end
-    end
-
-    class OracleEnhancedAdapter < AbstractAdapter
-      def delete_table(table_name)
-        execute("DELETE FROM #{quote_table_name(table_name)}")
-      end
-    end
-
-  end
-end
-
 
 module DatabaseCleaner::ActiveRecord
   class Deletion < Truncation
@@ -55,9 +10,11 @@ module DatabaseCleaner::ActiveRecord
     def clean
       connection = connection_class.connection
       connection.disable_referential_integrity do
-        tables_to_truncate(connection).each do |table_name|
-          connection.delete_table table_name
-        end
+        sql = tables_to_truncate(connection).map do |table_name|
+          "DELETE FROM #{connection.quote_table_name(table_name)}"
+        end.join(";")
+
+        connection.execute sql
       end
     end
 


### PR DESCRIPTION
Make the deletion strategy faster by sending all the delete commands
over the network in one go. In an application with 57 models this made
cleaning an empty database 50% faster on average with PostgreSQL 9.1.

Here's my test runs:

``` ruby
10.times.collect { Benchmark.ms { DatabaseCleaner.clean_with :deletion } }
```

before:

```
1.9.3-p327 :007 > [105.614286, 32.251335, 31.1513, 31.130746000000002, 34.937537999999996, 30.771834000000002, 37.270485, 105.021899, 30.165447, 32.301112].sum / 10
 => 47.061598200000006
```

after:

```
1.9.3-p327 :010 > [23.480825, 14.926957, 97.808237, 16.372389000000002, 15.162175, 16.282259, 19.892871, 16.298516, 15.101392, 15.880016].sum / 10
 => 25.120563700000005 
```

All specs didn't always pass but it doesn't seem related:

```
  1) DatabaseCleaner::Mongo::Truncation truncates all collections by default
     Failure/Error: model_class.count.should equal(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{model_class.count}"
       MongoTest::Widget expected to have a count of 0 but was 1
     # /home/betelgeuse/.rvm/gems/ruby-1.9.3-p327/gems/rspec-expectations-2.11.1/lib/rspec/expectations/fail_with.rb:33:in `fail_with'
     # /home/betelgeuse/.rvm/gems/ruby-1.9.3-p327/gems/rspec-expectations-2.11.1/lib/rspec/expectations/handler.rb:17:in `handle_matcher'
     # /home/betelgeuse/.rvm/gems/ruby-1.9.3-p327/gems/rspec-expectations-2.11.1/lib/rspec/expectations/syntax.rb:48:in `should'
     # ./spec/database_cleaner/mongo/truncation_spec.rb:27:in `block in ensure_counts'
```

As mentioned in #165 I couldn't get features to run but ActiveRecord related steps seemed to work.
