### PR TITLE
Added support for Moped (when used without Mongoid)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,6 +72,12 @@ Here is an overview of the strategies supported for each library:
       <td> No</td>
       <td> No</td>
     </tr>
+    <tr>
+      <td> Moped</td>
+      <td> Yes</td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
   </tbody>
 </table>
 
@@ -275,6 +281,11 @@ Usage beyond that remains the same with `DatabaseCleaner.start` calling any setu
       <td> Mongoid</td>
       <td> <code>DatabaseCleaner[:mongoid]</code></td>
       <td> Multiple databases supported for Mongoid 3. Specify <code>DatabaseCleaner[:mongoid, {:connection =&gt; :db_name}]</code> </td>
+    </tr>
+    <tr>
+      <td> Moped</td>
+      <td> <code>DatabaseCleaner[:moped]</code></td>
+      <td> It is necessary to configure database name with <code>DatabaseCleaner[:moped].db = db_name</code> otherwise name `default` will be used.</td>
     </tr>
     <tr>
       <td> Couch Potato</td>

--- a/lib/database_cleaner/moped/base.rb
+++ b/lib/database_cleaner/moped/base.rb
@@ -1,0 +1,35 @@
+require 'database_cleaner/generic/base'
+
+module DatabaseCleaner
+  module Moped
+    def self.available_strategies
+      %w[truncation]
+    end
+
+    module Base
+      include ::DatabaseCleaner::Generic::Base
+
+      def db=(desired_db)
+        @db = desired_db
+      end
+
+      def db
+        @db || :default
+      end
+
+      def host_port=(desired_host)
+        @host = desired_host
+      end
+
+      def host
+        @host || '127.0.0.1:27017'
+      end
+
+      private
+
+      def session
+        ::Moped::Session.new([host], database: db)
+      end
+    end
+  end
+end

--- a/lib/database_cleaner/moped/truncation.rb
+++ b/lib/database_cleaner/moped/truncation.rb
@@ -1,6 +1,11 @@
+require 'database_cleaner/moped/base'
+require 'database_cleaner/generic/truncation'
+
 module DatabaseCleaner
   module Moped
-    module Truncation
+    class Truncation
+      include ::DatabaseCleaner::Moped::Base
+      include ::DatabaseCleaner::Generic::Truncation
 
       def clean
         if @only
@@ -17,7 +22,7 @@ module DatabaseCleaner
         if db != :default
           session.use(db)
         end
-        
+
         session['system.namespaces'].find(:name => { '$not' => /system|\$/ }).to_a.map do |collection|
           _, name = collection['name'].split('.', 2)
           name

--- a/spec/database_cleaner/moped/moped_examples.rb
+++ b/spec/database_cleaner/moped/moped_examples.rb
@@ -1,0 +1,26 @@
+module MopedTest
+  class ThingBase
+    def self.collection
+      @db ||= 'database_cleaner_specs'
+      @session ||= ::Moped::Session.new(['127.0.0.1:27017'], database: @db)
+      @collection ||= @session[name]
+    end
+
+    def self.count
+      @collection.find.count
+    end
+
+    def initialize(attrs={})
+      @attrs = attrs
+    end
+
+    def save!
+      self.class.collection.insert(@attrs)
+    end
+  end
+
+  class Widget < ThingBase
+  end
+  class Gadget < ThingBase
+  end
+end

--- a/spec/database_cleaner/moped/truncation_spec.rb
+++ b/spec/database_cleaner/moped/truncation_spec.rb
@@ -1,0 +1,75 @@
+require File.dirname(__FILE__) + '/../../spec_helper'
+require 'moped'
+require 'database_cleaner/moped/truncation'
+require File.dirname(__FILE__) + '/moped_examples'
+
+module DatabaseCleaner
+  module Moped
+
+    describe Truncation do
+      let(:args) {{}}
+      let(:truncation) { described_class.new(args).tap { |t| t.db=@db } }
+      #doing this in the file root breaks autospec, doing it before(:all) just fails the specs
+      before(:all) do
+        @test_db = 'database_cleaner_specs'
+        @session = ::Moped::Session.new(['127.0.0.1:27017'], database: @test_db)
+      end
+
+      before(:each) do
+        truncation.db = @test_db
+      end
+
+      after(:each) do
+        @session.drop
+      end
+
+      def ensure_counts(expected_counts)
+        # I had to add this sanity_check garbage because I was getting non-determinisc results from mongo at times..
+        # very odd and disconcerting...
+        expected_counts.each do |model_class, expected_count|
+          model_class.count.should equal(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{model_class.count}"
+        end
+      end
+
+      def create_widget(attrs={})
+        MopedTest::Widget.new({:name => 'some widget'}.merge(attrs)).save!
+      end
+
+      def create_gadget(attrs={})
+        MopedTest::Gadget.new({:name => 'some gadget'}.merge(attrs)).save!
+      end
+
+      it "truncates all collections by default" do
+        create_widget
+        create_gadget
+        ensure_counts(MopedTest::Widget => 1, MopedTest::Gadget => 1)
+        truncation.clean
+        ensure_counts(MopedTest::Widget => 0, MopedTest::Gadget => 0)
+      end
+
+      context "when collections are provided to the :only option" do
+        let(:args) {{:only => ['MopedTest::Widget']}}
+        it "only truncates the specified collections" do
+          create_widget
+          create_gadget
+          ensure_counts(MopedTest::Widget => 1, MopedTest::Gadget => 1)
+          truncation.clean
+          ensure_counts(MopedTest::Widget => 0, MopedTest::Gadget => 1)
+        end
+      end
+
+      context "when collections are provided to the :except option" do
+        let(:args) {{:except => ['MopedTest::Widget']}}
+        it "truncates all but the specified collections" do
+          create_widget
+          create_gadget
+          ensure_counts(MopedTest::Widget => 1, MopedTest::Gadget => 1)
+          truncation.clean
+          ensure_counts(MopedTest::Widget => 1, MopedTest::Gadget => 0)
+        end
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
It allows to use `DatabaseCleaner` when only Moped is used (without Mongoid).
