### PR TITLE
Make clean_with work for multiple db connections

### DIFF
--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -36,17 +36,21 @@ module DatabaseCleaner
 
     def clean_with(*args)
       strategy = create_strategy(*args)
-      if strategy.respond_to? :db=
-        strategy.db = self.db
-      elsif self.db != :default
-        raise ArgumentError, "You must provide a strategy object that supports non default databases when you specify a database"
-      end
+      set_strategy_db strategy, self.db
 
       strategy.clean
       strategy
     end
 
     alias clean_with! clean_with
+
+    def set_strategy_db(strategy, desired_db)
+      if strategy.respond_to? :db=
+        strategy.db = desired_db
+      elsif desired_db != :default
+        raise ArgumentError, "You must provide a strategy object that supports non default databases when you specify a database"
+      end
+    end
 
     def strategy=(args)
       strategy, *strategy_args = args
@@ -58,7 +62,7 @@ module DatabaseCleaner
          raise ArgumentError, "You must provide a strategy object, or a symbol for a known strategy along with initialization params."
        end
 
-       self.strategy_db = self.db
+       set_strategy_db @strategy, self.db
 
        @strategy
     end

--- a/spec/database_cleaner/base_spec.rb
+++ b/spec/database_cleaner/base_spec.rb
@@ -334,7 +334,7 @@ module DatabaseCleaner
 
       it "should attempt to set strategy db" do
         subject.stub(:db).and_return(:my_db)
-        subject.should_receive(:strategy_db=).with(:my_db)
+        subject.should_receive(:set_strategy_db).with(mock_strategy, :my_db)
         subject.strategy = mock_strategy
       end
 


### PR DESCRIPTION
clean_with avoids using strategy= so that it doesn't actually change the
strategy. This means it was bypassing the section that set the database
to actually clean and therefore it was always cleaning the default.
