### PR TITLE
Remove attempt to establish connections with anonymous classes in ActiveRecord.

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -38,10 +38,6 @@ module DatabaseCleaner
         end
       end
 
-      def create_connection_class
-        Class.new(::ActiveRecord::Base)
-      end
-
       def connection_class
         @connection_class ||= if @db && !@db.is_a?(Symbol)
                                 @db
@@ -63,9 +59,7 @@ module DatabaseCleaner
       end
 
       def establish_connection
-        strategy_class = create_connection_class
-        strategy_class.send :establish_connection, connection_hash
-        strategy_class
+        ::ActiveRecord::Base.establish_connection(connection_hash)
       end
 
     end

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -119,16 +119,6 @@ my_db:
         end
       end
 
-      describe "create_connection_class" do
-        it "should return a class" do
-          subject.create_connection_class.should be_a(Class)
-        end
-
-        it "should return a class extending ::ActiveRecord::Base" do
-          subject.create_connection_class.ancestors.should include(::ActiveRecord::Base)
-        end
-      end
-
       describe "connection_class" do
         it { expect { subject.connection_class }.to_not raise_error }
         it "should default to ActiveRecord::Base" do
@@ -158,16 +148,9 @@ my_db:
           before { ::ActiveRecord::Base.stub!(:respond_to?).and_return(false) }
           before { subject.stub(:connection_hash).and_return(hash) }
 
-          it "should create connection_class if it doesnt exist if connection_hash is set" do
-            subject.should_receive(:create_connection_class).and_return(mock('class').as_null_object)
-            subject.connection_class
-          end
+          it "establish a connection using ActiveRecord::Base" do
+            ::ActiveRecord::Base.should_receive(:establish_connection).with(hash)
 
-          it "should configure the class from create_connection_class if connection_hash is set" do
-            strategy_class = mock('strategy_class')
-            strategy_class.should_receive(:establish_connection).with(hash)
-
-            subject.should_receive(:create_connection_class).and_return(strategy_class)
             subject.connection_class
           end
         end


### PR DESCRIPTION
I ran into this issue when trying to upgrade a project to Rails 4. ActiveRecord 4 no longer allows establishing connections with the use of anonymous classes:

https://github.com/rails/rails/issues/8934

I believe my attached commits should fix this issue by calling establish_connection directly on ActiveRecord::Base instead of through an anonymous class.
