### PR TITLE
Fix for transaction strategy problem in Rails4 rc1

### DIFF
--- a/lib/database_cleaner/active_record/transaction.rb
+++ b/lib/database_cleaner/active_record/transaction.rb
@@ -9,7 +9,7 @@ module DatabaseCleaner::ActiveRecord
     def start
       # Hack to make sure that the connection is properly setup for
       # the clean code.
-      connection_class.connection.transaction
+      connection_class.connection.transaction{ }
 
       if connection_maintains_transaction_count?
         if connection_class.connection.respond_to?(:increment_open_transactions)


### PR DESCRIPTION
As reported in #200, ActiveRecord transaction strategy breaks when testing a Rails 4.0.0.rc1 application, because ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction no longer allow block-less calling.
This pull request fixes it by passing an empty block.
