### PR TITLE
Use mongoid connection instead of Mongo gem

### DIFF
--- a/examples/lib/mongoid_models.rb
+++ b/examples/lib/mongoid_models.rb
@@ -2,7 +2,7 @@ require 'mongoid'
 
 Mongoid.configure do |config|
   name = 'database_cleaner_test'
-  config.master = Mongo::Connection.new.db(name)
+  config.connect_to(name)
 end
 
 


### PR DESCRIPTION
mongoid version > 3.0.0 use configure below:
http://mongoid.org/en/mongoid/docs/installation.html#configuration
I use stackoverflow answer:
http://stackoverflow.com/questions/12511699/mongoid-uninitialized-constant-mongo-nameerror
