### PR TITLE
Fix MySqlAdapter superclass bug via class_eval loading of superclasses

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -176,54 +176,37 @@ module ActiveRecord
   module ConnectionAdapters
     # Activerecord-jdbc-adapter defines class dependencies a bit differently - if it is present, confirm to ArJdbc hierarchy to avoid 'superclass mismatch' errors.
     USE_ARJDBC_WORKAROUND = defined?(ArJdbc)
+    # ActiveRecord 3.1+ support
+    MYSQL_ABSTRACT_ADAPTER = defined?(AbstractMysqlAdapter) ? AbstractMysqlAdapter : AbstractAdapter
 
-    class AbstractAdapter
-      include ::DatabaseCleaner::ActiveRecord::AbstractAdapter
-    end
+    AbstractAdapter.send(:include, ::DatabaseCleaner::ActiveRecord::AbstractAdapter)
 
-    unless USE_ARJDBC_WORKAROUND
-      class SQLiteAdapter < AbstractAdapter
-      end
-    end
-
-    # ActiveRecord 3.1 support
-    if defined?(AbstractMysqlAdapter)
-      MYSQL_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractMysqlAdapter
-      MYSQL2_ADAPTER_PARENT = AbstractMysqlAdapter
+    if USE_ARJDBC_WORKAROUND
+      MYSQL_ADAPTER_PARENT  = JdbcAdapter
     else
-      MYSQL_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
-      MYSQL2_ADAPTER_PARENT = AbstractAdapter
+      MYSQL_ADAPTER_PARENT  = MYSQL_ABSTRACT_ADAPTER
+      class SQLiteAdapter < AbstractAdapter; end
     end
+    MYSQL2_ADAPTER_PARENT = MYSQL_ABSTRACT_ADAPTER
 
     if defined?(SQLite3Adapter) && SQLite3Adapter.superclass == ActiveRecord::ConnectionAdapters::AbstractAdapter
       SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
     else
       SQLITE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : SQLiteAdapter
     end
-    POSTGRE_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
+    POSTGRES_ADAPTER_PARENT = USE_ARJDBC_WORKAROUND ? JdbcAdapter : AbstractAdapter
 
-    class MysqlAdapter < MYSQL_ADAPTER_PARENT
-      include ::DatabaseCleaner::ActiveRecord::MysqlAdapter
-    end
-
-    class Mysql2Adapter < MYSQL2_ADAPTER_PARENT
-      include ::DatabaseCleaner::ActiveRecord::MysqlAdapter
-    end
+    MYSQL_ADAPTER_PARENT.class_eval     { include ::DatabaseCleaner::ActiveRecord::MysqlAdapter }
+    MYSQL2_ADAPTER_PARENT.class_eval    { include ::DatabaseCleaner::ActiveRecord::MysqlAdapter }
+    SQLITE_ADAPTER_PARENT.class_eval    { include ::DatabaseCleaner::ActiveRecord::SQLiteAdapter }
+    POSTGRES_ADAPTER_PARENT.class_eval  { include ::DatabaseCleaner::ActiveRecord::PostgreSQLAdapter }
 
     class IBM_DBAdapter < AbstractAdapter
       include ::DatabaseCleaner::ActiveRecord::IBM_DBAdapter
     end
 
-    class SQLite3Adapter < SQLITE_ADAPTER_PARENT
-      include ::DatabaseCleaner::ActiveRecord::SQLiteAdapter
-    end
-
     class JdbcAdapter < AbstractAdapter
       include ::DatabaseCleaner::ActiveRecord::TruncateOrDelete
-    end
-
-    class PostgreSQLAdapter < POSTGRE_ADAPTER_PARENT
-      include ::DatabaseCleaner::ActiveRecord::PostgreSQLAdapter
     end
 
     class SQLServerAdapter < AbstractAdapter
@@ -233,7 +216,6 @@ module ActiveRecord
     class OracleEnhancedAdapter < AbstractAdapter
       include ::DatabaseCleaner::ActiveRecord::OracleEnhancedAdapter
     end
-
   end
 end
 

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -1,5 +1,9 @@
 require File.dirname(__FILE__) + '/../../spec_helper'
 require 'active_record'
+require 'active_record/connection_adapters/mysql_adapter'
+require 'active_record/connection_adapters/mysql2_adapter'
+require 'active_record/connection_adapters/sqlite3_adapter'
+require 'active_record/connection_adapters/postgresql_adapter'
 
 require 'database_cleaner/active_record/truncation'
 
@@ -119,14 +123,14 @@ module DatabaseCleaner
           subject.send(:pre_count?).should == false
         end
       end
-      
+
       describe '#reset_ids?' do
         before(:each) do
           connection.stub!(:disable_referential_integrity).and_yield
           connection.stub!(:database_cleaner_view_cache).and_return([])
           ::ActiveRecord::Base.stub!(:connection).and_return(connection)
         end
-        
+
         subject { Truncation.new }
         its(:reset_ids?) { should == true }
 

--- a/spec/support/active_record/mysql2_setup.rb
+++ b/spec/support/active_record/mysql2_setup.rb
@@ -1,6 +1,7 @@
 require 'support/active_record/database_setup'
 require 'support/active_record/schema_setup'
 
+
 module MySQL2Helper
   puts "Active Record #{ActiveRecord::VERSION::STRING}, mysql2"
 
@@ -36,3 +37,4 @@ end
 RSpec.configure do |c|
   c.include MySQL2Helper
 end
+


### PR DESCRIPTION
To get it working with my current setup (a lot of gem dependencies) and Rails 3.2.13.

Removing the `superclass mismatch for class MysqlAdapter` by `class_eval` as opposed to monkey patching the superclass.

It was still erroring for me with the fix in #185. Would be great if @etagwerker (or others where this is an issue) could check if this fix also works for them.
