### PR TITLE
History.txt is now History.rdoc

### DIFF
--- a/database_cleaner.gemspec
+++ b/database_cleaner.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   ]
   s.files = [
     "Gemfile.lock",
-    "History.txt",
+    "History.rdoc",
     "README.markdown",
     "Rakefile",
     "VERSION.yml",


### PR DESCRIPTION
Fixes:

```
database_cleaner at /Users/parndt/.rvm/gems/ruby-2.0.0-p195/bundler/gems/database_cleaner-6a3d236b0089 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["History.txt"] are not files
```
