### PR TITLE
Sequel expects table names to be symbols

### DIFF
--- a/lib/database_cleaner/sequel/truncation.rb
+++ b/lib/database_cleaner/sequel/truncation.rb
@@ -28,7 +28,7 @@ module DatabaseCleaner
 
       def each_table
         tables_to_truncate(db).each do |table|
-          yield db, table
+          yield db, table.to_sym
         end
       end
 


### PR DESCRIPTION
Unfortunately I don't have enough time (or patience) to add tests as there is currently no tests for Sequel. :(
