### PR TITLE
Respect ActiveRecord's table_name_prefix option on schema_migrations

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -244,7 +244,7 @@ module DatabaseCleaner::ActiveRecord
 
     # overwritten
     def migration_storage_names
-      %w[schema_migrations]
+      [::ActiveRecord::Migrator.schema_migrations_table_name]
     end
 
     def pre_count?

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -39,6 +39,16 @@ module DatabaseCleaner
           Truncation.new.clean
         end
 
+        it "should use ActiveRecord's schema_migrations_table_name" do
+          connection.stub!(:database_cleaner_table_cache).and_return(%w[pre_schema_migrations_suf widgets dogs])
+          ::ActiveRecord::Base.stub!(:table_name_prefix).and_return('pre_')
+          ::ActiveRecord::Base.stub!(:table_name_suffix).and_return('_suf')
+
+          connection.should_receive(:truncate_tables).with(['widgets', 'dogs'])
+
+          Truncation.new.clean
+        end
+
         it "should only truncate the tables specified in the :only option when provided" do
           connection.stub!(:database_cleaner_table_cache).and_return(%w[schema_migrations widgets dogs])
 


### PR DESCRIPTION
This makes ActiveRecord responsible for determining the table name to
handle subtle nuisances like table_name_prefix and table_name_suffix. See issue #213.
