### PR TITLE
Request for #autoloadable?

### DIFF
--- a/lib/database_cleaner.rb
+++ b/lib/database_cleaner.rb
@@ -1,3 +1,8 @@
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.include?(File.expand_path(File.dirname(__FILE__)))
 require 'database_cleaner/configuration'
 
+module DatabaseCleaner
+  def self.can_detect_orm?
+    DatabaseCleaner::Base.autodetect_orm
+  end
+end

--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -1,7 +1,6 @@
 require 'database_cleaner/null_strategy'
 module DatabaseCleaner
   class Base
-
     def initialize(desired_orm = nil,opts = {})
       if [:autodetect, nil, "autodetect"].include?(desired_orm)
         autodetect
@@ -98,6 +97,28 @@ module DatabaseCleaner
       self.orm == other.orm && self.db == other.db
     end
 
+    def autodetect_orm
+      if defined? ::ActiveRecord
+        :active_record
+      elsif defined? ::DataMapper
+        :data_mapper
+      elsif defined? ::MongoMapper
+        :mongo_mapper
+      elsif defined? ::Mongoid
+        :mongoid
+      elsif defined? ::CouchPotato
+        :couch_potato
+      elsif defined? ::Sequel
+        :sequel
+      elsif defined? ::Moped
+        :moped
+      elsif defined? ::Ohm
+        :ohm
+      elsif defined? ::Redis
+        :redis
+      end
+    end
+
     private
 
     def orm_module
@@ -116,30 +137,10 @@ module DatabaseCleaner
     end
 
     def autodetect
-      @orm ||= begin
-        @autodetected = true
-        if defined? ::ActiveRecord
-          :active_record
-        elsif defined? ::DataMapper
-          :data_mapper
-        elsif defined? ::MongoMapper
-          :mongo_mapper
-        elsif defined? ::Mongoid
-          :mongoid
-        elsif defined? ::CouchPotato
-          :couch_potato
-        elsif defined? ::Sequel
-          :sequel
-        elsif defined? ::Moped
-          :moped
-        elsif defined? ::Ohm
-          :ohm
-        elsif defined? ::Redis
-          :redis
-        else
-          raise NoORMDetected, "No known ORM was detected!  Is ActiveRecord, DataMapper, Sequel, MongoMapper, Mongoid, Moped, or CouchPotato, Redis or Ohm loaded?"
-        end
-      end
+      @autodetected = true
+
+      @orm ||= autodetect_orm ||
+               raise(NoORMDetected, "No known ORM was detected!  Is ActiveRecord, DataMapper, Sequel, MongoMapper, Mongoid, Moped, or CouchPotato, Redis or Ohm loaded?")
     end
 
     def set_default_orm_strategy


### PR DESCRIPTION
@bmabey I'm not sure if you'd be open to this, so I'm asking here first before I submit a PR.

I have a gem which works with RSpec to try and handle a bunch of setup/use cases for common gems which work with RSpec.  The main goal for [my gem](/jfelchner/rspectacular) is to be a drop-in replacement for a spec_helper but which is faster and more portable for everyone (eg no more copying and pasting the same code for the same gems in all your projects) as well as easier for newbies to get up and running without having to know the details.

For the [database_cleaner portion](https://github.com/jfelchner/rspectacular/blob/70e289f82b75d00b366d762b06adf0bad85031d2/lib/rspectacular/plugins/database_cleaner.rb) I'm utilizing the best practices outlined in the wiki for enabling the fastest tests possible for various testing scenarios (eg javascript vs unit tests vs no DB tests).

The problem I'm running in to is that, when database_cleaner is included in a project, it's attempting to load it for tests which require database access _and also_ for those which don't.  

Example:

```
rspec database_needed_spec.rb
# Finishes Successfully
```

```
rspec spec
# Finishes Successfully
```

```
rspec active_record_not_loaded_spec.rb
# Fails Because Database Cleaner Can't Find Any ORMs
```

This hurts because it means that I _have_ to include an ORM even on those specs which don't include it.  My workaround is ([full file with hacky workaround](https://github.com/jfelchner/rspectacular/blob/e18df5801df354288cabee64d2cc62c4447d0e55/lib/rspectacular/plugins/database_cleaner.rb)):

``` ruby
  begin
    autodetected = DatabaseCleaner::Base.new.send(:autodetect)
  rescue DatabaseCleaner::NoORMDetected
    autodetected = false
  end

  if autodetected
     # Load DatabaseCleaner hooks
  end
```

Not only is it ugly, not only is it using an exception to drive flow, but it's using one of database_cleaner's private API calls.

What I'd _like_ to have is something like:

``` ruby
if DatabaseCleaner.can_detect_orm?
   # Load DatabaseCleaner hooks
end
```

So my questions are: Can you think of a better way to do this? and Are you opposed to the idea of adding a method like this to the public API?
