### PR TITLE
Define uses_sequence that checks if there is a table named sqlite_sequence

### DIFF
--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -65,6 +65,12 @@ module DataMapper
         yield
       end
 
+      private
+
+      # Returns a boolean indicating if the SQLite database is using the sqlite_sequence table.
+      def uses_sequence
+        select("SELECT name FROM sqlite_master WHERE type='table' AND name='sqlite_sequence';").include?("sqlite_sequence")
+      end
     end
 
     class SqliteAdapter < DataObjectsAdapter
@@ -94,6 +100,12 @@ module DataMapper
         yield
       end
 
+      private
+
+      # Returns a boolean indicating if the SQLite database is using the sqlite_sequence table.
+      def uses_sequence
+        select("SELECT name FROM sqlite_master WHERE type='table' AND name='sqlite_sequence';").include?("sqlite_sequence")
+      end
     end
 
     # FIXME


### PR DESCRIPTION
SQLite truncation error `no such table: sqlite_sequence` has been fixed by @lightswitch05. However, when we use DataMapper and SQLite, `undefined method or variable 'uses_sequence'` will be raised because it is only defined for ActiveRecord.

I added `uses_sequence` for DataMapper and it is working fine now.
Related issue: https://github.com/amatsuda/kaminari/pull/406
