### PR TITLE
Support Oracle JDBC Adapter

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -114,13 +114,13 @@ module DatabaseCleaner
       def truncate_table(table_name)
         begin
           execute("TRUNCATE TABLE #{quote_table_name(table_name)};")
-        rescue ActiveRecord::StatementInvalid
+        rescue ::ActiveRecord::StatementInvalid
           execute("DELETE FROM #{quote_table_name(table_name)};")
         end
       end
     end
 
-    module OracleEnhancedAdapter
+    module OracleAdapter
       def truncate_table(table_name)
         execute("TRUNCATE TABLE #{quote_table_name(table_name)}")
       end
@@ -176,7 +176,13 @@ module ActiveRecord
     #Apply adapter decoraters where applicable (adapter should be loaded)
     AbstractAdapter.class_eval { include DatabaseCleaner::ConnectionAdapters::AbstractAdapter }
 
-    JdbcAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::TruncateOrDelete } if defined?(JdbcAdapter)
+    if defined?(JdbcAdapter)
+      if defined?(OracleJdbcConnection)
+        JdbcAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::OracleAdapter }
+      else
+        JdbcAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::TruncateOrDelete }
+      end
+    end
     AbstractMysqlAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::AbstractMysqlAdapter } if defined?(AbstractMysqlAdapter)
     Mysql2Adapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::AbstractMysqlAdapter } if defined?(Mysql2Adapter)
     SQLiteAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::SQLiteAdapter } if defined?(SQLiteAdapter)
@@ -184,7 +190,7 @@ module ActiveRecord
     PostgreSQLAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::PostgreSQLAdapter } if defined?(PostgreSQLAdapter)
     IBM_DBAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::IBM_DBAdapter } if defined?(IBM_DBAdapter)
     SQLServerAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::TruncateOrDelete } if defined?(SQLServerAdapter)
-    OracleEnhancedAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::OracleEnhancedAdapter } if defined?(OracleEnhancedAdapter)
+    OracleEnhancedAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::OracleAdapter } if defined?(OracleEnhancedAdapter)
   end
 end
 


### PR DESCRIPTION
I tried using database_cleaner on a Rails project using the ActiveRecord JDBC Adapter on an Oracle database. The first issue I came across was the following error message when trying to truncate:

```
NameError: uninitialized constant DatabaseCleaner::ActiveRecord::StatementInvalid
```

I traced this an improperly scoped class reference at `lib/database_cleaner/active_record/truncation.rb:117`.

Then I received `ORA-00911: invalid character` errors when trying to truncate. Oracle does not support semi-colons in TRUNCATE TABLE statements. So we need to use the same syntax with a JdbcOracleConnection as used by the OracleEnhancedAdapter.
