### PR TITLE
Use respond_to? with true to check inspect private/protected methods

### DIFF
--- a/lib/database_cleaner/active_record/transaction.rb
+++ b/lib/database_cleaner/active_record/transaction.rb
@@ -36,7 +36,7 @@ module DatabaseCleaner::ActiveRecord
       end
 
       # The below is for handling after_commit hooks.. see https://github.com/bmabey/database_cleaner/issues/99
-      if connection_class.connection.respond_to?(:rollback_transaction_records)
+      if connection_class.connection.respond_to?(:rollback_transaction_records, true)
         connection_class.connection.send(:rollback_transaction_records, true)
       end
 


### PR DESCRIPTION
I expect it to fix the memory leak described in: https://github.com/bmabey/database_cleaner/issues/204
But it doesn't 100% helps. 

Anyway, the problem is that starting from 1.9.3 `respond_to?` returns `true` only for public methods, so to make it work against `private` we need to add second optional parameter as `true`.
