### PR TITLE
Making the mysql deletion cleaner to touch only those tables that have new records in them

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -54,3 +54,17 @@ module DatabaseCleaner::ActiveRecord
     end
   end
 end
+
+if defined?(Mysql2Adapter)
+  class DatabaseCleaner::ActiveRecord::Deletion
+    def tables_to_truncate(connection)
+      (@only || tables_with_new_rows(connection)) - @tables_to_exclude
+    end
+
+    def tables_with_new_rows(connection)
+      @db_name ||= connection.instance_variable_get('@config')[:database]
+      result = connection.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = '#{@db_name}' AND table_rows > 0")
+      result.map{ |row| row[0] } - ['schema_migrations']
+    end
+  end
+end


### PR DESCRIPTION
Hey guys, here is a little something to speed up the deletion strategy under mysql.

basically the idea is that it checks the mysql metadata and gets the list of tables that have new records in them and then deletes data only from those tables. It gives really nice boost on large projects where there are dozens of tables to clean up.

I've described the principles in this little blog post, in case you're interested http://theosom.com/p/SFGN
