### PR TITLE
Fix "undefined local variable or method `adapter'"

### DIFF
--- a/lib/database_cleaner/data_mapper/truncation.rb
+++ b/lib/database_cleaner/data_mapper/truncation.rb
@@ -12,7 +12,7 @@ module DataMapper
 
       def truncate_tables(table_names)
         table_names.each do |table_name|
-          adapter.truncate_table table_name
+          truncate_table table_name
         end
       end
 


### PR DESCRIPTION
NameError: undefined local variable or method `adapter' for #<DataMapper::Adapters::SqliteAdapter:0x88caa5c>
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/data_mapper/truncation.rb:15:in`block in truncate_tables'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/data_mapper/truncation.rb:14:in `each'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/data_mapper/truncation.rb:14:in`truncate_tables'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/data_mapper/truncation.rb:192:in `block in clean'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/data_mapper/truncation.rb:110:in`disable_referential_integrity'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/data_mapper/truncation.rb:191:in `clean'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/base.rb:86:in`clean'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/configuration.rb:79:in `block in clean'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/configuration.rb:79:in`each'
    /home/pirj/.rvm/gems/ruby-2.1.2@g5/gems/database_cleaner-1.3.0/lib/database_cleaner/configuration.rb:79:in `clean'
