### PR TITLE
Updated regexp for filter system collections

### DIFF
--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -23,7 +23,7 @@ module DatabaseCleaner
           session.use(db)
         end
 
-        session['system.namespaces'].find(:name => { '$not' => /system|\$/ }).to_a.map do |collection|
+        session['system.namespaces'].find(:name => { '$not' => /\.system\.|\$/ }).to_a.map do |collection|
           _, name = collection['name'].split('.', 2)
           name
         end


### PR DESCRIPTION
Now it's possible to clean collections with names like:

```
favourite_systems
operating_systems
systems
```

and so on.

All real mongo's system collections have following name format (as in 2.4.1):

```
{db_name}.system.{system_collection_type}
```
