### PR TITLE
always return Postgres table names with schema to avoid awfulness

### DIFF
--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -35,6 +35,12 @@ module ActiveRecord
         end
       end
 
+      describe '#database_cleaner_table_cache' do
+        it 'should default to the list of tables with their schema' do
+          connection.database_cleaner_table_cache.first.should match(/^public\./)
+        end
+      end
+
       it_behaves_like "an adapter with pre-count truncation" do
         let(:connection) { active_record_pg_connection }
       end


### PR DESCRIPTION
- without the schema, the migrations table gets truncated since the default AR method returns ‘public.schema_migrations’
- also a possibility is truncation of tables other than desired once since without the schema, Postgres has no way of knowing which table to truncate if two schemas have the same table
