### PR TITLE
PostgreSQL truncation for tables without sequence

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -160,8 +160,14 @@ module DatabaseCleaner
       # but then the table is cleaned.  In other words, this function tells us if the given table
       # was ever inserted into.
       def has_been_used?(table)
+        return has_rows?(table) unless has_sequence?(table)
+
         cur_val = select_value("SELECT currval('#{table}_id_seq');").to_i rescue 0
         cur_val > 0
+      end
+      
+      def has_sequence?(table)
+        select_value("SELECT true FROM pg_class WHERE relname = '#{table}_id_seq';")
       end
 
       def has_rows?(table)

--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -27,6 +27,13 @@ module ActiveRecord
           User.count.should eq 0
         end
 
+        it "truncates the table without id sequence" do
+          2.times { Agent.create }
+
+          connection.truncate_table('agents')
+          Agent.count.should eq 0
+        end
+
         it "resets AUTO_INCREMENT index of table" do
           2.times { User.create }
           User.delete_all
@@ -45,4 +52,3 @@ module ActiveRecord
     end
   end
 end
-

--- a/spec/support/active_record/schema_setup.rb
+++ b/spec/support/active_record/schema_setup.rb
@@ -3,8 +3,15 @@ def load_schema
     create_table :users, :force => true do |t|
       t.integer :name
     end
+
+    create_table :agents, :id => false, :force => true do |t|
+      t.integer :name
+    end
   end
 end
 
 class ::User < ActiveRecord::Base
+end
+
+class ::Agent < ActiveRecord::Base
 end


### PR DESCRIPTION
If we try to get current value of unexisting sequence, PG will raise an exception. Resque that by zero, we drop table from truncation list.