### PR TITLE
Moped cleaner misses collections that have 'system' in their name

### DIFF
--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -23,7 +23,7 @@ module DatabaseCleaner
           session.use(db)
         end
 
-        session['system.namespaces'].find(:name => { '$not' => /system|\$/ }).to_a.map do |collection|
+        session['system.namespaces'].find(:name => { '$not' => /\.system\.|\$/ }).to_a.map do |collection|
           _, name = collection['name'].split('.', 2)
           name
         end

--- a/spec/database_cleaner/moped/moped_examples.rb
+++ b/spec/database_cleaner/moped/moped_examples.rb
@@ -23,4 +23,10 @@ module MopedTest
   end
   class Gadget < ThingBase
   end
+  class System < ThingBase
+    def self.collection
+      super
+      @collection = @session['system_logs']
+    end
+  end
 end

--- a/spec/database_cleaner/moped/truncation_spec.rb
+++ b/spec/database_cleaner/moped/truncation_spec.rb
@@ -39,12 +39,17 @@ module DatabaseCleaner
         MopedTest::Gadget.new({:name => 'some gadget'}.merge(attrs)).save!
       end
 
+      def create_system(attrs={})
+        MopedTest::System.new({:name => 'some system'}.merge(attrs)).save!
+      end
+
       it "truncates all collections by default" do
         create_widget
         create_gadget
-        ensure_counts(MopedTest::Widget => 1, MopedTest::Gadget => 1)
+        create_system
+        ensure_counts(MopedTest::Widget => 1, MopedTest::Gadget => 1, MopedTest::System => 1)
         truncation.clean
-        ensure_counts(MopedTest::Widget => 0, MopedTest::Gadget => 0)
+        ensure_counts(MopedTest::Widget => 0, MopedTest::Gadget => 0, MopedTest::System => 0)
       end
 
       context "when collections are provided to the :only option" do


### PR DESCRIPTION
The regex that matches mongodb system collections is too broad and also matches any other collection that carries 'system' in it's name.
