### PR TITLE
Specify full namespace for Mysql2Adapter

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -55,7 +55,7 @@ module DatabaseCleaner::ActiveRecord
   end
 end
 
-if defined?(Mysql2Adapter)
+if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
   class DatabaseCleaner::ActiveRecord::Deletion
     def tables_to_truncate(connection)
       (@only || tables_with_new_rows(connection)) - @tables_to_exclude


### PR DESCRIPTION
Followup fix for 8d0016e (PR https://github.com/DatabaseCleaner/database_cleaner/pull/265). This probably worked in some cases because of weird
magic Rails does to constant lookup [1].

[1] http://urbanautomaton.com/blog/2013/08/27/rails-autoloading-hell/
