### PR TITLE
Use ruby 1.8 syntax

### DIFF
--- a/lib/database_cleaner/active_record/transaction.rb
+++ b/lib/database_cleaner/active_record/transaction.rb
@@ -19,7 +19,7 @@ module DatabaseCleaner::ActiveRecord
         end
       end
       if connection_class.connection.respond_to?(:begin_transaction)
-        connection_class.connection.begin_transaction joinable: false
+        connection_class.connection.begin_transaction :joinable => false
       else
         connection_class.connection.begin_db_transaction
       end

--- a/spec/database_cleaner/sequel/deletion_spec.rb
+++ b/spec/database_cleaner/sequel/deletion_spec.rb
@@ -43,8 +43,8 @@ module DatabaseCleaner
     end
 
     supported_configurations = [
-      { url: 'mysql:///', connection_options: db_config['mysql'] },
-      { url: 'postgres:///', connection_options: db_config['postgres'] }
+      { :url => 'mysql:///', :connection_options => db_config['mysql'] },
+      { :url => 'postgres:///', :connection_options => db_config['postgres'] }
     ]
 
     supported_configurations.each do |config|


### PR DESCRIPTION
I was trying to use database cleaner on a ruby 1.8.7 environment and found this issue.