### PR TITLE
Fix `cannot load such file -- mongoid/tree (LoadError)` (Mongoid 4.0.0)

### DIFF
--- a/lib/database_cleaner/mongoid/truncation.rb
+++ b/lib/database_cleaner/mongoid/truncation.rb
@@ -2,7 +2,6 @@ require 'database_cleaner/mongoid/base'
 require 'database_cleaner/generic/truncation'
 require 'database_cleaner/mongo/truncation_mixin'
 require 'database_cleaner/moped/truncation_base'
-require 'mongoid/tree'
 require 'mongoid/version'
 
 module DatabaseCleaner


### PR DESCRIPTION
Hey there,

i just updated to version `1.4.0` and with Mongoid `4.0.0` an error `cannot load such file -- mongoid/tree (LoadError)` occurred.

I just looked at the history, with the commit https://github.com/DatabaseCleaner/database_cleaner/commit/61feda02e0999a684951f2afb6746fd2ddf814f4 the line `require 'mongoid/tree'` was added. Is this needed, without the line everything works?

PS: Maybe @etagwerker should take a look at it.

PPS: Many thanks for database_cleaner!