### PR TITLE
Update History.rdoc file for 1.4.0

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,19 +1,24 @@
 == Development (master)
 
 === New Features/Changes
-  * Using the deletion strategy with Mysql now only deletes those tables
-    which have had records added to them. (@MadRabbit)
-  * Add support for `pre_count` on Sequel with Mysql. (@vrinek)
-  * Add support for neo4j. (@dpisarewski)
-  * Cache collection names in mongo's truncation strategy. (@nyarly)
-  * Support for mongoid multiple connections. (@nyarly)
   * Support for deletion with Sequel. (@cyberdelia)
 
+== 1.4.0 2014-12-17
+
+=== New Features/Changes
+  * Support for Neo4j. (@dpisarewski)
+  * Support for multiple connections on Mongoid. (@nyarly)
+
+=== Better Performance
+  * Using the deletion strategy with Mysql now only deletes those tables which have had records added to them. (@MadRabbit)
+  * Add support for pre_count on Sequel with Mysql. (@vrinek)
+  * Cache collection names in mongo's truncation strategy. (@nyarly)
+
 === Bug Fixes
-  * Fix `undefined method error` with DataMapper SQLite adaptor. (@lanej)
+  * Fix undefined method error with DataMapper SQLite adaptor. (@lanej)
   * Fully define Mysql2 adaptor constant. (@jgonera)
   * Don't truncate schema tables in Postgres. (@billywatson)
-  * Fix issue #284. (@MartinNowak)
+  * Fix issue where Moped cleaner was missing collections with 'system' in their name. (@MartinNowak)
 
 == 1.3.0 2014-05-23
 


### PR DESCRIPTION
@etagwerker - This addresses issue #321, based off of blog post (http://databasecleaner.github.io/2014/12/17/v1-4-0-is-out/) and commit history.