### PR TITLE
except tables not working with postgresql schema prefix

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -244,8 +244,8 @@ module DatabaseCleaner::ActiveRecord
       tables_in_db = cache_tables? ? connection.database_cleaner_table_cache : connection.tables
       to_reject = (@tables_to_exclude + connection.database_cleaner_view_cache)
       (@only || tables_in_db).reject do |table|
-          if table.match(/([^.]+)$/)
-            to_reject.include?($1)
+          if ( m = table.match(/([^.]+)$/) )
+            to_reject.include?(m[1])
           else
             false
           end

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -24,7 +24,7 @@ module DatabaseCleaner
       def database_cleaner_view_cache
         @views ||= select_values("select table_name from information_schema.views where table_schema = '#{current_database}'") rescue []
       end
-      
+
       def database_cleaner_table_cache
         # the adapters don't do caching (#130) but we make the assumption that the list stays the same in tests
         @database_cleaner_tables ||= tables
@@ -177,7 +177,7 @@ module DatabaseCleaner
         cur_val = select_value("SELECT currval('#{table}_id_seq');").to_i rescue 0
         cur_val > 0
       end
-      
+
       def has_sequence?(table)
         select_value("SELECT true FROM pg_class WHERE relname = '#{table}_id_seq';")
       end
@@ -242,7 +242,14 @@ module DatabaseCleaner::ActiveRecord
 
     def tables_to_truncate(connection)
       tables_in_db = cache_tables? ? connection.database_cleaner_table_cache : connection.tables
-      (@only || tables_in_db) - @tables_to_exclude - connection.database_cleaner_view_cache
+      to_reject = (@tables_to_exclude + connection.database_cleaner_view_cache)
+      (@only || tables_in_db).reject do |table|
+          if table.match(/([^.]+)$/)
+            to_reject.include?($1)
+          else
+            false
+          end
+        end
     end
 
     # overwritten

--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -55,7 +55,7 @@ module ActiveRecord
         it "should not truncate the tables specified in the :except option" do
           2.times { User.create }
 
-          ::DatabaseCleaner::ActiveRecord:Truncation.new(:except => ['user']).clean
+          ::DatabaseCleaner::ActiveRecord::Truncation.new(:except => ['user']).clean
           expect( User.count ).to eq 2
         end
       end

--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -55,7 +55,7 @@ module ActiveRecord
         it "should not truncate the tables specified in the :except option" do
           2.times { User.create }
 
-          ::DatabaseCleaner::ActiveRecord::Truncation.new(:except => ['user']).clean
+          ::DatabaseCleaner::ActiveRecord::Truncation.new(:except => ['users']).clean
           expect( User.count ).to eq 2
         end
       end

--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -42,6 +42,15 @@ module ActiveRecord
         end
       end
 
+      describe ":except option cleanup" do
+        it "should not truncate the tables specified in the :except option" do
+          2.times { User.create }
+
+          ::DatabaseCleaner::ActiveRecord:Truncation.new(:except => ['user']).clean
+          expect( User.count ).to eq 2
+        end
+      end
+
       describe '#database_cleaner_table_cache' do
         it 'should default to the list of tables with their schema' do
           connection.database_cleaner_table_cache.first.should match(/^public\./)


### PR DESCRIPTION
I define tables as strings containing only name of table and in postgres i get schema prefix in name. So simple array - not working for me. With this change except work on postges. Its a bit slower, but it keeps schema prefix and works as expected.