### PR TITLE
Add license to gemspec

### DIFF
--- a/database_cleaner.gemspec
+++ b/database_cleaner.gemspec
@@ -140,6 +140,7 @@ Gem::Specification.new do |s|
     "spec/support/data_mapper/sqlite3_setup.rb"
   ]
   s.homepage = "http://github.com/bmabey/database_cleaner"
+  s.license = 'MIT'
   s.rubygems_version = "2.4.5"
   s.summary = "Strategies for cleaning databases.  Can be used to ensure a clean state for testing."
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.