### PR TITLE
Exclude schema_migrations from tables_with_schema

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -190,7 +190,10 @@ module DatabaseCleaner
         rows = select_rows <<-_SQL
           SELECT schemaname || '.' || tablename
           FROM pg_tables
-          WHERE tablename !~ '_prt_' AND schemaname = ANY (current_schemas(false))
+          WHERE 
+            tablename !~ '_prt_' AND 
+            tablename <> '#{::ActiveRecord::Migrator.schema_migrations_table_name}' AND 
+            schemaname = ANY (current_schemas(false))
         _SQL
         rows.collect { |result| result.first }
       end


### PR DESCRIPTION
This is a fix for https://github.com/DatabaseCleaner/database_cleaner/issues/317 .
The easiest way to handle the problem (as I think) is to exclude migrations table from table list while loading it, because we don't know anything about schema. Thus generic `migration_storage_names` makes no sense when using with Postrges. 

