### PR TITLE
Don't truncate the schema_migrations table

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+database_cleaner

--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -6,6 +6,15 @@ require 'database_cleaner/active_record/truncation/shared_fast_truncation'
 
 module ActiveRecord
   module ConnectionAdapters
+    describe "schema_migrations table" do
+      it "is not truncated" do
+        active_record_gp_migrate
+        DatabaseCleaner::ActiveRecord::Truncation.new.clean
+        result = active_record_pg_connection.execute("select count(*) from schema_migrations;")
+        result.values.first.should eq ["2"]
+      end
+    end
+
     describe do
       before(:all) { active_record_pg_setup }
 

--- a/spec/support/active_record/migrations/20150101010000_create_users.rb
+++ b/spec/support/active_record/migrations/20150101010000_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration
+  def self.up
+    create_table :users do |t|
+      t.string :name
+    end
+  end
+
+  def self.down
+    drop_table :users
+  end
+end
+
+class ::User < ActiveRecord::Base
+end

--- a/spec/support/active_record/migrations/20150101020000_create_agents.rb
+++ b/spec/support/active_record/migrations/20150101020000_create_agents.rb
@@ -1,0 +1,14 @@
+class CreateAgents < ActiveRecord::Migration
+  def self.up
+    create_table :agents do |t|
+      t.string :name
+    end
+  end
+
+  def self.down
+    drop_table :agents
+  end
+end
+
+class ::Agent < ActiveRecord::Base
+end

--- a/spec/support/active_record/postgresql_setup.rb
+++ b/spec/support/active_record/postgresql_setup.rb
@@ -31,6 +31,13 @@ module PostgreSQLHelper
     load_schema
   end
 
+  def active_record_gp_migrate
+    `dropdb #{config['database']}`
+    create_db
+    establish_connection
+    ActiveRecord::Migrator.migrate 'spec/support/active_record/migrations'
+  end
+
   def active_record_pg_connection
     ActiveRecord::Base.connection
   end


### PR DESCRIPTION
This adds much needed coverage to active_record's migration table behavior.

Thank you, @jonallured! 