### PR TITLE
Fix truncation on MongoDB 3

### DIFF
--- a/lib/database_cleaner/moped/base.rb
+++ b/lib/database_cleaner/moped/base.rb
@@ -25,6 +25,10 @@ module DatabaseCleaner
         @host ||= '127.0.0.1:27017'
       end
 
+      def db_version
+        @db_version ||= session.command('buildinfo' => 1)['version']
+      end
+
       private
 
       def session

--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -23,10 +23,11 @@ module DatabaseCleaner
           session.use(db)
         end
 
-        session.command(listCollections: 1)[:cursor][:firstBatch].map do |collection|
-          collection[:name]
-        end.reject do |collection_name|
-          collection_name =~ /system|\$/
+        session.command(listCollections: 1)['cursor']['firstBatch'].map do |collection|
+          collection['name']
+        end
+        .reject do |collection_name|
+          collection_name =~ /\.system\.|\$/
         end
       end
 

--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -23,11 +23,18 @@ module DatabaseCleaner
           session.use(db)
         end
 
-        session.command(listCollections: 1)['cursor']['firstBatch'].map do |collection|
-          collection['name']
-        end
-        .reject do |collection_name|
-          collection_name =~ /\.system\.|\$/
+        if db_version.split('.').first.to_i >= 3
+          session.command(listCollections: 1)['cursor']['firstBatch'].map do |collection|
+            collection['name']
+          end
+          .reject do |collection_name|
+            collection_name =~ /\.system\.|\$/
+          end
+        else
+          session['system.namespaces'].find(name: { '$not' => /\.system\.|\$/ }).to_a.map do |collection|
+            _, name = collection['name'].split('.', 2)
+            name
+          end
         end
       end
 

--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -23,9 +23,10 @@ module DatabaseCleaner
           session.use(db)
         end
 
-        session['system.namespaces'].find(:name => { '$not' => /\.system\.|\$/ }).to_a.map do |collection|
-          _, name = collection['name'].split('.', 2)
-          name
+        session.command(listCollections: 1)[:cursor][:firstBatch].map do |collection|
+          collection[:name]
+        end.reject do |collection_name|
+          collection_name =~ /system|\$/
         end
       end
 

--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -24,11 +24,8 @@ module DatabaseCleaner
         end
 
         if db_version.split('.').first.to_i >= 3
-          session.command(listCollections: 1)['cursor']['firstBatch'].map do |collection|
+          session.command(listCollections: 1, filter: { 'name' => { '$not' => /.?system\.|\$/ } })['cursor']['firstBatch'].map do |collection|
             collection['name']
-          end
-          .reject do |collection_name|
-            collection_name =~ /\.system\.|\$/
           end
         else
           session['system.namespaces'].find(name: { '$not' => /\.system\.|\$/ }).to_a.map do |collection|


### PR DESCRIPTION
As reported on the [mongoDB documentation](system.namespaces), the collection `system.namespaces` is deprecated and can no longer be used to list the database collections.

![5ca89421407c3a033eed20b4997a64c6](https://cloud.githubusercontent.com/assets/8267744/6525305/4dd4230c-c404-11e4-92d5-01eafee438cf.png)

This PR addresses the deprecation issue by using the command `listCollections` instead. This allow DatabaseCleaner to work with MongoDB 3 with WiredTiger storage engine.
