### PR TITLE
Require YAML in gemspec.

### DIFF
--- a/database_cleaner.gemspec
+++ b/database_cleaner.gemspec
@@ -1,3 +1,5 @@
+require 'yaml'
+
 version = YAML.load_file 'VERSION.yml'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Previously, when bundling the database cleaner gem, an error was raised due to YAML not being loaded.

```
Updating https://github.com/DatabaseCleaner/database_cleaner.git

There was a NameError while loading database_cleaner.gemspec: 

uninitialized constant YAML from
.../app/vendor/bundle/bundler/gems/database_cleaner-a8157176681a/database_cleaner.gemspec:1:in `<main>'
```

This was introduced in a8157176681af8f5a4dcc0cd57d9952bd03c7dfa. Requiring YAML fixes the issue.