### PR TITLE
Fixed deletion strategy for JDBC MySQL adapter

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -54,8 +54,8 @@ module DatabaseCleaner::ActiveRecord
 
     def tables_with_new_rows(connection)
       @db_name ||= connection.instance_variable_get('@config')[:database]
-      result = connection.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = '#{@db_name}' AND table_rows > 0")
-      result.map{ |row| row[0] } - ['schema_migrations']
+      result = connection.exec_query("SELECT table_name FROM information_schema.tables WHERE table_schema = '#{@db_name}' AND table_rows > 0")
+      result.map{ |row| row['table_name'] } - ['schema_migrations']
     end
 
     def information_schema_exists? connection


### PR DESCRIPTION
It seems the JDBC MySQL adapter creates an ActiveRecord::ConnectionAdapters::Mysql2Adapter constant that causes the SelectiveTruncation module to be included in the active record Deletion class.  Everything works fine except the real MySQL adapter returns results differently from the JDBC adapter.  Changing the execute method to exec_query allows it to work for both adapters.