### PR TITLE
Ensure @cleaners has been defined before reading

### DIFF
--- a/lib/database_cleaner/configuration.rb
+++ b/lib/database_cleaner/configuration.rb
@@ -42,7 +42,7 @@ module DatabaseCleaner
 
     def connections
       # double yuck.. can't wait to deprecate this whole class...
-      unless @cleaners
+      unless defined?(@cleaners) && @cleaners
         autodetected = ::DatabaseCleaner::Base.new
         add_cleaner(autodetected.orm)
       end


### PR DESCRIPTION
To avoid Ruby warnings like:
```
.bundle/ruby/2.1.0/gems/database_cleaner-1.4.1/lib/database_cleaner/configuration.rb:45: warning: instance variable @cleaners not initialized
```