### PR TITLE
Reduce mongoid_collection_names complexity

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Each strategy is a small amount of code but is code that is usually needed in an
 
 ActiveRecord, DataMapper, Sequel, MongoMapper, Mongoid, CouchPotato, Ohm and Redis are supported.
 
-[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner)
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner) [![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner)
 
 Here is an overview of the strategies supported for each library:
 

--- a/lib/database_cleaner/mongo/truncation.rb
+++ b/lib/database_cleaner/mongo/truncation.rb
@@ -20,10 +20,7 @@ module DatabaseCleaner
       def mongoid_collection_names
         @@mongoid_collection_names ||= Hash.new{|h,k| h[k]=[]}.tap do |names|
           ObjectSpace.each_object(Class) do |klass|
-            next unless klass.ancestors.map(&:to_s).include?('Mongoid::Document')
-            next if klass.embedded
-            next if klass.collection_name.empty?
-            names[klass.db.name] << klass.collection_name
+            (names[klass.db.name] << klass.collection_name) if valid_collection_name?(klass)
           end
         end
       end
@@ -51,6 +48,14 @@ module DatabaseCleaner
         end
 
         db_collections
+      end
+
+      private
+
+      def valid_collection_name?(klass)
+        klass.ancestors.map(&:to_s).include?('Mongoid::Document') &&
+        !klass.embedded &&
+        !klass.collection_name.empty?
       end
     end
   end


### PR DESCRIPTION
I was browsing Code Climate for some OSS repos to contribute to, and saw that database_cleaner was already on Code Climate with an excellent GPA! Not much to change here but I figured I'd help clarify a method that Code Climate flagged as complex. I also added our badge to your README. Cheers!