### PR TITLE
Adds support for additional Neo4j::Session.open options

### DIFF
--- a/lib/database_cleaner/neo4j/base.rb
+++ b/lib/database_cleaner/neo4j/base.rb
@@ -50,8 +50,12 @@ module DatabaseCleaner
         database[:path]
       end
 
+      def db_params
+        database.reject!{|key, value| [:type, :path].include? key }
+      end
+
       def session
-        @session ||= ::Neo4j::Session.open(db_type, db_path)
+        @session ||= ::Neo4j::Session.open(db_type, db_path, db_params)
       end
     end
   end

--- a/spec/database_cleaner/neo4j/base_spec.rb
+++ b/spec/database_cleaner/neo4j/base_spec.rb
@@ -24,6 +24,13 @@ module DatabaseCleaner
         subject.db.should eq db_conf
       end
 
+      it "should respect additional connection parameters" do
+        db_conf = {:type => :server_db, :path => 'http://localhost:7474', basic_auth: {username: 'user', password: 'pass'}}
+        subject.db = db_conf
+        stub_const("Neo4j::Session", double()).should_receive(:open).with(:server_db, 'http://localhost:7474', {basic_auth: {username: 'user', password: 'pass'}}) { true }
+        subject.start
+      end
+
       it "should default to nil" do
         subject.db.should be_nil
       end


### PR DESCRIPTION
The current Neo4j support only passed through path and type parameters, but Neo4j::Session.open can also take in a third 'params' option for specifying things like connection profile or authentication. This change passes through the additional options to the Session.open call