### PR TITLE
Update README documentation for ActiveRecord with Truncation.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -197,7 +197,7 @@ The following options are available for ActiveRecord's `:truncation` strategy _o
 
 The following option is available for ActiveRecord's `:truncation` and `:deletion` strategy for any DB.
 
-* `:cache_tables` - When set to `true` the list of tables to truncate or delete from will only be read from the DB once, otherwise it will be read before each cleanup run. Set this to `false` if you create and drop tables in your tests. Defaults to `true`.
+* `:cache_tables` - When set to `true` the list of tables to truncate or delete from will only be read from the DB once, otherwise it will be read before each cleanup run. Set this to `false` if (1) you create and drop tables in your tests, or (2) you change Postgres schemas (`ActiveRecord::Base.connection.schema_search_path`) in your tests (for example, in a multitenancy setup with each tenant in a different Postgres schema). Defaults to `true`.
 
 
 ### RSpec Example


### PR DESCRIPTION
The case I ran into:

2 Postgres schemas: tenant1 and tenant2

Set `ActiveRecord::Base.connection.schema_search_path = "tenant1"`
Run DatabaseCleaner.clean with truncation strategy
Result: tenant1 schema tables are cleaned (as expected!)

Set `ActiveRecord::Base.connection.schema_search_path = "tenant2"`
Run DatabaseCleaner.clean with truncation strategy
Result: tenant1 schema tables are cleaned (unexepected result, as records are still left in tenant2 schema tables!)

The already available `cache_tables: false` option is also useful in the case of switching schemas, not just for adding and dropping tables in your tests. I added documentation for that. Hopefully somebody Cmd-F finds the word "multitenancy" or "Postgres schema" and this helps them!

Thanks for managing this excellent project.