### PR TITLE
Fix an issue when the mysql2 gem is included in a project that uses non-mysql databases.

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -59,7 +59,7 @@ module DatabaseCleaner::ActiveRecord
     end
 
     def is_mysql2? connection
-      connection.class == 'ActiveRecord::ConnectionAdapters::Mysql2Adapter'
+      connection.class.to_s == 'ActiveRecord::ConnectionAdapters::Mysql2Adapter'
     end
 
     def clean


### PR DESCRIPTION
The old implementation assumed if the gem was present, that all databases were mysql. Connecting to a DB of any other type would cause exceptions. Instead, we check the connection adapter type in each instance of the cleaner, and only use the mysql2 specific code when using the mysql2 adapter.
