### PR TITLE
Less hacky way to obtain connection database name for deletion.

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -53,7 +53,7 @@ module DatabaseCleaner::ActiveRecord
     end
 
     def tables_with_new_rows(connection)
-      @db_name ||= connection.instance_variable_get('@config')[:database]
+      @db_name ||= connection.pool.spec.config[:database]
       result = connection.exec_query("SELECT table_name FROM information_schema.tables WHERE table_schema = '#{@db_name}' AND table_rows > 0")
       result.map{ |row| row['table_name'] } - ['schema_migrations']
     end

--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -53,7 +53,7 @@ module DatabaseCleaner::ActiveRecord
     end
 
     def tables_with_new_rows(connection)
-      @db_name ||= connection.pool.spec.config[:database]
+      @db_name ||= connection_config(connection)[:database]
       result = connection.exec_query("SELECT table_name FROM information_schema.tables WHERE table_schema = '#{@db_name}' AND table_rows > 0")
       result.map{ |row| row['table_name'] } - ['schema_migrations']
     end
@@ -66,6 +66,16 @@ module DatabaseCleaner::ActiveRecord
         rescue
           false
         end
+    end
+
+    private
+
+    def connection_config(connection)
+      if ([ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] <=> [3, 2]) >= 0
+        connection.pool.spec.config
+      else
+        connection.instance_variable_get('@config')
+      end
     end
   end
 

--- a/spec/database_cleaner/active_record/deletion_spec.rb
+++ b/spec/database_cleaner/active_record/deletion_spec.rb
@@ -1,0 +1,40 @@
+require File.dirname(__FILE__) + '/../../spec_helper'
+require 'active_record'
+require 'active_record/connection_adapters/mysql_adapter'
+require 'active_record/connection_adapters/mysql2_adapter'
+require 'active_record/connection_adapters/sqlite3_adapter'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+require 'database_cleaner/active_record/deletion'
+
+describe DatabaseCleaner::ActiveRecord::Deletion do
+  let(:connection) { double('connection') }
+
+  before(:each) do
+    connection.stub(:disable_referential_integrity).and_yield
+    connection.stub(:database_cleaner_view_cache).and_return([])
+    ::ActiveRecord::Base.stub(:connection).and_return(connection)
+  end
+
+  describe '#clean' do
+    it "deletes all tables that need cleaning" do
+      connection.should_receive(:delete_table).with('widgets').once
+      connection.should_receive(:delete_table).with('dogs').once
+
+      strategy = DatabaseCleaner::ActiveRecord::Deletion.new
+      strategy.stub(:tables_to_truncate).and_return(%w[widgets dogs])
+      strategy.clean
+    end
+
+    it "only cleans tables in rows if information_schema exists" do
+      connection.stub(:database_cleaner_table_cache).and_return(['schema_migrations', 'widgets', 'dogs'])
+      connection.stub(:execute).with("SELECT 1 FROM information_schema.tables")
+      connection.stub(:instance_variable_get).with('@config').and_return(database: 'DATABASE')
+      connection.stub_chain(:pool, :spec, :config).and_return(database: 'DATABASE')
+      connection.stub(:exec_query).with("SELECT table_name FROM information_schema.tables WHERE table_schema = 'DATABASE' AND table_rows > 0").
+        and_return([{'table_name' => 'widgets'}, {'table_name' => 'schema_migrations'}])
+      strategy = DatabaseCleaner::ActiveRecord::Deletion.new
+      strategy.send(:tables_to_truncate, connection).should == ['widgets']
+    end
+  end
+end

--- a/spec/database_cleaner/moped/truncation_spec.rb
+++ b/spec/database_cleaner/moped/truncation_spec.rb
@@ -27,7 +27,8 @@ module DatabaseCleaner
         # I had to add this sanity_check garbage because I was getting non-determinisc results from mongo at times..
         # very odd and disconcerting...
         expected_counts.each do |model_class, expected_count|
-          model_class.count.should equal(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{model_class.count}"
+          actual_count = model_class.count
+          actual_count.should equal(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{actual_count}"
         end
       end
 


### PR DESCRIPTION
In addition to violating encapsulation a little less, this allows
cleaning the correct shard when used with the popular octopus gem.
