### PR TITLE
Redis deprecations

### DIFF
--- a/examples/lib/redis_models.rb
+++ b/examples/lib/redis_models.rb
@@ -3,7 +3,7 @@ require 'redis'
 class RedisWidget
 
   def self.redis
-    threaded ||= Redis.connect
+    threaded ||= Redis.new
   end
 
   def self.redis=(connection)
@@ -45,7 +45,7 @@ end
 class RedisWidgetUsingDatabaseOne < RedisWidget
 
   def self.redis
-    threaded[self.class.to_s] ||= Redis.connect :url => ENV['REDIS_URL_ONE']
+    threaded[self.class.to_s] ||= Redis.new :url => ENV['REDIS_URL_ONE']
   end
 
   def self.create!
@@ -56,7 +56,7 @@ end
 class RedisWidgetUsingDatabaseTwo < RedisWidget
 
   def self.redis
-    threaded[self.class.to_s] ||= Redis.connect :url => ENV['REDIS_URL_TWO']
+    threaded[self.class.to_s] ||= Redis.new :url => ENV['REDIS_URL_TWO']
   end
 
   def self.create!

--- a/lib/database_cleaner/redis/base.rb
+++ b/lib/database_cleaner/redis/base.rb
@@ -22,7 +22,7 @@ module DatabaseCleaner
       private
 
       def connection
-        @connection ||= url == :default ? ::Redis.connect : ::Redis.connect(:url => url)
+        @connection ||= url == :default ? ::Redis.new : ::Redis.new(:url => url)
       end
 
     end

--- a/lib/database_cleaner/redis/base.rb
+++ b/lib/database_cleaner/redis/base.rb
@@ -22,10 +22,16 @@ module DatabaseCleaner
       private
 
       def connection
-        @connection ||= url == :default ? ::Redis.new : ::Redis.new(:url => url)
+        @connection ||= begin
+          if url == :default
+            ::Redis.new
+          elsif db.class.is_a?(::Redis) # pass directly the connection
+            db
+          else
+            ::Redis.new(:url => url)
+          end
+        end
       end
-
     end
   end
 end
-

--- a/spec/database_cleaner/redis/base_spec.rb
+++ b/spec/database_cleaner/redis/base_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'redis'
 require 'database_cleaner/redis/base'
 require 'database_cleaner/shared_strategy'
 
@@ -18,10 +19,20 @@ module DatabaseCleaner
       it { should respond_to(:db) }
       it { should respond_to(:db=) }
 
-      it "should store my describe db" do
-        url = 'redis://localhost:6379/2'
-        subject.db = 'redis://localhost:6379/2'
-        subject.db.should eq url
+      context "when passing url" do
+        it "should store my describe db" do
+          url = 'redis://localhost:6379/2'
+          subject.db = 'redis://localhost:6379/2'
+          subject.db.should eq url
+        end
+      end
+
+      context "when passing connection" do
+        it "should store my describe db" do
+          connection = ::Redis.new :url => 'redis://localhost:6379/2'
+          subject.db = connection
+          subject.db.should eq connection
+        end
       end
 
       it "should default to :default" do

--- a/spec/database_cleaner/redis/truncation_spec.rb
+++ b/spec/database_cleaner/redis/truncation_spec.rb
@@ -9,7 +9,7 @@ module DatabaseCleaner
     describe Truncation do
       before(:all) do
         config = YAML::load(File.open("#{File.dirname(__FILE__)}/../../../examples/config/redis.yml"))
-      @redis = ::Redis.connect :url => config['test']['url']
+      @redis = ::Redis.new :url => config['test']['url']
       end
 
       before(:each) do


### PR DESCRIPTION
* Replace `Redis.connect`[deprecated] with `Redis.new`
* Add ability to pass directly the redis connection instead of redis url.