### PR TITLE
README, suggest append_after to ensure proper order of cleanup

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -246,7 +246,14 @@ See the suggested config below to temporarily enable truncation strategy
 for affected feature specs only. This config continues to use transaction
 strategy for all other specs.
 
+It's also recommended to use `append_after` to ensure `DatabaseCleaner.clean`
+runs *after* the after-test cleanup `capybara/rspec` installs.
+
 ```ruby
+require 'capybara/rspec'
+
+#...
+
 RSpec.configure do |config|
 
   config.use_transactional_fixtures = false
@@ -288,7 +295,7 @@ RSpec.configure do |config|
     DatabaseCleaner.start
   end
 
-  config.after(:each) do
+  config.append_after(:each) do
     DatabaseCleaner.clean
   end
 


### PR DESCRIPTION
It's best to have DatabaseCleaner.clean run AFTER capybara cleanup, in case capybara cleanup ends up triggering anything that could be interrupted by the database cleaner. 

`require 'capybara/rspec'` installs an after hook for Capybara cleanup. 

rspec after hooks are run in _reverse_ order of definition, after hooks defined last are run first. So with `require 'capybara/rspec'` at top of file, and then later manually defining an after hook for DC cleanup... DC cleanup fires before capybara's cleanup. 

Using RSpec's `append_after` instead of `after` fixes this. With so many timing issues that can go wrong with capybara, might as well eliminate one more potential one.