### PR TITLE
update travis bundler before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
 script: "bundle exec rake"
 gemfile:
   - Gemfile
+before_install:
+  - gem update bundler
 before_script:
   - mysql -e 'create database database_cleaner_test;'
   - psql -c 'create database database_cleaner_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script: "bundle exec rake"
 gemfile:
   - Gemfile
 before_install:
-  - gem update bundler
+  - gem install bundler -v 1.11.2
 before_script:
   - mysql -e 'create database database_cleaner_test;'
   - psql -c 'create database database_cleaner_test;' -U postgres


### PR DESCRIPTION
Travis builds are currently failing on the new infrastructure.

```
NoMethodError: undefined method `spec' for nil:NilClass
```
and
```
An error occurred while installing
database_cleaner (1.5.1), and Bundler
cannot continue.
Make sure that `gem install
database_cleaner -v '1.5.1'` succeeds
before bundling.
```

As advised in https://github.com/travis-ci/travis-ci/issues/3531, it seems to be necessary to install a newer bundler version before running `bundle install`.