### PR TITLE
Don't try to use mysql-specific information_schema

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -59,6 +59,7 @@ module DatabaseCleaner::ActiveRecord
     end
 
     def information_schema_exists? connection
+      return false unless connection.is_a? ActiveRecord::ConnectionAdapters::Mysql2Adapter
       @information_schema_exists ||=
         begin
           connection.execute("SELECT 1 FROM information_schema.tables")


### PR DESCRIPTION
Fixes https://github.com/DatabaseCleaner/database_cleaner/issues/345

I tried to add specs, but it looks like there currently aren't any real specs for the deletion strategy (correct me if I'm wrong), and ActiveRecord is locked at 3.0.0 which doesn't support `exec_query`. Updating everything seemed like a pretty major undertaking--I'd be happy to write some real specs once that's done.