### PR TITLE
Use variable methods based on Mongo version [Fixes #379]

### DIFF
--- a/lib/database_cleaner/mongo/truncation_mixin.rb
+++ b/lib/database_cleaner/mongo/truncation_mixin.rb
@@ -4,9 +4,9 @@ module DatabaseCleaner
 
       def clean
         if @only
-          collections.each { |c| c.remove if @only.include?(c.name) }
+          collections.each { |c| c.send(truncate_method_name) if @only.include?(c.name) }
         else
-          collections.each { |c| c.remove unless @tables_to_exclude.include?(c.name) }
+          collections.each { |c| c.send(truncate_method_name) unless @tables_to_exclude.include?(c.name) }
         end
         true
       end
@@ -17,6 +17,10 @@ module DatabaseCleaner
         database.collections.select { |c| c.name !~ /^system\./ }
       end
 
+      def truncate_method_name
+        # This constant only exists in the 2.x series.
+        defined?(::Mongo::VERSION) ? :delete_many : :remove
+      end
     end
   end
 end


### PR DESCRIPTION
The "delete all the things" method name changed between Mongo drivers
1.x and 2.x, so detecting the new version allows us to run delete_many
rather than remove.