### PR TITLE
Fix Neo4j in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ gemfile:
   - Gemfile
 before_install:
   - gem install bundler -v 1.11.2
+  # install Neo4j locally:
+  - wget dist.neo4j.org/neo4j-community-2.3.3-unix.tar.gz
+  - tar -xzf neo4j-community-2.3.3-unix.tar.gz
+  - sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-2.3.3/conf/neo4j-server.properties
+  - neo4j-community-2.3.3/bin/neo4j start
 before_script:
   - mysql -e 'create database database_cleaner_test;'
   - psql -c 'create database database_cleaner_test;' -U postgres
@@ -16,4 +21,3 @@ before_script:
 services:
   - redis-server
   - mongodb
-  - neo4j


### PR DESCRIPTION
Currently Neo4j refuses to run in Travis' new container-based architecture.

I'm not sure why these builds do succeed, perhaps caching helps here. However I've forked the repository, set up Travis builds for my fork and… Neo4j [refuses to start](https://s3.amazonaws.com/archive.travis-ci.org/jobs/119683298/log.txt). Not even on master of which HEAD equals to original master's HEAD.

I suppose that anyone who will fork the repository and set up Travis builds will stumble upon the same issue.

The problem can be mitigated by installing custom Neo4j version as pointed out here: https://github.com/travis-ci/travis-ci/issues/3243