### PR TITLE
Detect mongoid version to use correct method.

### DIFF
--- a/lib/database_cleaner/mongoid/truncation.rb
+++ b/lib/database_cleaner/mongoid/truncation.rb
@@ -28,7 +28,7 @@ module DatabaseCleaner
         private
 
         def session
-          ::Mongoid.default_client
+          ::Mongoid::VERSION > "5.0.0" ? ::Mongoid.default_client : ::Mongoid.default_session
         end
 
         def database


### PR DESCRIPTION
 "default_session" is replaced with "default_client" in mongoid version >= 5.0.0

This would make database_cleaner run with older versions of Mongoid.