### PR TITLE
Update to json 1.8.3 to fix issue for bundle install.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    database_cleaner (1.5.2)
+    database_cleaner (1.5.3)
 
 GEM
   remote: https://rubygems.org/
@@ -141,9 +141,9 @@ GEM
     httpclient (2.5.3.3)
     i18n (0.4.2)
     jdbc-sqlite3 (3.8.10.1)
-    json (1.8.1)
-    json (1.8.1-java)
-    json_pure (1.8.1)
+    json (1.8.3)
+    json (1.8.3-java)
+    json_pure (1.8.3)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -283,4 +283,4 @@ DEPENDENCIES
   tzinfo
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
Hi,
## Summary

I failed to do "bundle install" in my environment.
So, I update dependency gem package json from 1.8.1 to latest version: 1.8.3 in Gemfile.lock.

I just updated below 3 lines in Gemfile.lock.
However other 2 line were updated, when I succeeded to "bundle install".
I used bundler latest version: 1.12.5 for that.

```
-    json (1.8.1)
-    json (1.8.1-java)
-    json_pure (1.8.1)
+    json (1.8.3)
+    json (1.8.3-java)
+    json_pure (1.8.3)
```
## Detail

My environment is Fedora 23.

```
$ gcc --version
gcc (GCC) 5.3.1 20160406 (Red Hat 5.3.1-6)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
```

```
$ bundle install --path vendor/bundle
...
Installing json 1.8.1 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/jaruga/git/database_cleaner/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
/usr/local/ruby-2.3.1/bin/ruby -r ./siteconf20160603-11142-q93i3x.rb extconf.rb
creating Makefile

current directory: /home/jaruga/git/database_cleaner/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /home/jaruga/git/database_cleaner/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [-Wint-conversion]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
Makefile:238: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/jaruga/git/database_cleaner/vendor/bundle/ruby/2.3.0/gems/json-1.8.1 for inspection.
Results logged to /home/jaruga/git/database_cleaner/vendor/bundle/ruby/2.3.0/extensions/x86_64-linux/2.3.0-static/json-1.8.1/gem_make.out
```

I referred below json's page. It is recommended to update json to 1.8.3 for ruby 2.2.
https://github.com/flori/json/issues/229

Could you merge this to master branch?

Thanks.
