### PR TITLE
Adding support for neo4j-core 7.0.x (neo4j 8)

### DIFF
--- a/lib/database_cleaner/neo4j/deletion.rb
+++ b/lib/database_cleaner/neo4j/deletion.rb
@@ -8,7 +8,7 @@ module DatabaseCleaner
 
       def clean
         transaction do
-          query('MATCH (n) OPTIONAL MATCH (n)-[r]-() DELETE n,r')
+          query('MATCH (n) WHERE NOT (n:`Neo4j::Migrations::SchemaMigration`) OPTIONAL MATCH (n)-[r]-() DELETE n,r')
         end
       end
 

--- a/lib/database_cleaner/neo4j/deletion.rb
+++ b/lib/database_cleaner/neo4j/deletion.rb
@@ -7,8 +7,18 @@ module DatabaseCleaner
       include ::DatabaseCleaner::Neo4j::Base
 
       def clean
-        ::Neo4j::Transaction.run do
-          session._query('MATCH (n) OPTIONAL MATCH (n)-[r]-() DELETE n,r')
+        transaction do
+          query('MATCH (n) OPTIONAL MATCH (n)-[r]-() DELETE n,r')
+        end
+      end
+
+      private
+
+      def transaction(&block)
+        if legacy_neo4j?
+          ::Neo4j::Transaction.run(&block)
+        else
+          ::Neo4j::Transaction.run(session, &block)
         end
       end
     end

--- a/lib/database_cleaner/neo4j/transaction.rb
+++ b/lib/database_cleaner/neo4j/transaction.rb
@@ -13,7 +13,7 @@ module DatabaseCleaner
       def start
         super
         rollback
-        self.tx = ::Neo4j::Transaction.new
+        self.tx = new_transaction
       end
 
       def clean
@@ -29,6 +29,10 @@ module DatabaseCleaner
         end
       ensure
         self.tx = nil
+      end
+
+      def new_transaction
+        legacy_neo4j? ? ::Neo4j::Transaction.new : ::Neo4j::Transaction.new(session)
       end
     end
   end


### PR DESCRIPTION
Hi!
Soon there will be a release of `neo4j-core` 7.0.x (currently in alpha), that changes entirely the connection/session API, and comes with the new `BOLT` protocol support.

There will be many breaking changes on how sessions are created, that influences how `database_cleaner` would work with it.

For example:
There's no more a `current_session`, because you can have multiple sessions using different adaptors. As a consequence, running queries and transactions requires to have an instance of a `::Neo4j::Core::CypherSession` object

The "current_session" concept was moved to [`neo4j`](https://github.com/neo4jrb/neo4j) gem, the ActiveRecord-like ORM for neo4j. If you're using it, the most simple way to migrate settings would be to change this:

``` ruby
    DatabaseCleaner[:neo4j, connection: {
      type: Rails.application.config.neo4j.session_type,
      path: Rails.application.config.neo4j.session_path
    }]
```

into this:

``` ruby
    DatabaseCleaner[:neo4j, connection: { current_session: Neo4j::ActiveBase.current_session}]
```

If you're using `neo4j-core` without it, instead, you can pass to `DatabaseCleaner` your opened session to `current_session` or also the connection settings.

I made a few changes to `DatabaseCleaner`, so it should support both `neo4j-core < 7.0` and `>= 7.0`

P.S. I'm still working on this 😜 
