### PR TITLE
Fix truncation method for old versions of mongodb

### DIFF
--- a/lib/database_cleaner/mongo/truncation_mixin.rb
+++ b/lib/database_cleaner/mongo/truncation_mixin.rb
@@ -18,8 +18,8 @@ module DatabaseCleaner
       end
 
       def truncate_method_name
-        # This constant only exists in the 2.x series.
-        defined?(::Mongo::VERSION) ? :delete_many : :remove
+        # This constant doesn't exist in 1.8.x to 1.12.x versions
+        defined?(::Mongo::VERSION) && ::Mongo::VERSION >= "2.0.0" ? :delete_many : :remove
       end
     end
   end

--- a/spec/database_cleaner/mongo/truncation_mixin_spec.rb
+++ b/spec/database_cleaner/mongo/truncation_mixin_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+require "database_cleaner/mongo/truncation_mixin"
+
+describe DatabaseCleaner::Mongo::TruncationMixin do
+  let(:klass) do
+    Class.new do
+      include DatabaseCleaner::Mongo::TruncationMixin
+
+      def initialize(database:)
+        @tables_to_exclude = []
+        @database = database
+      end
+
+      def database
+        @database
+      end
+    end
+  end
+
+  describe "#clean" do
+    it "calls 'remove' method for mongo versions < 2.0" do
+      stub_const("::Mongo::VERSION", "1.5.1")
+      collection = double(name: "foo")
+      allow(collection).to receive(:remove)
+      database = double(collections: [collection])
+
+      klass.new(database: database).clean
+
+      expect(collection).to have_received(:remove)
+    end
+
+    it "calls 'delete_many' method for mongo versions >= 2.0" do
+      stub_const("::Mongo::VERSION", "2.0.0")
+      collection = double(name: "foo")
+      allow(collection).to receive(:delete_many)
+      database = double(collections: [collection])
+
+      klass.new(database: database).clean
+
+      expect(collection).to have_received(:delete_many)
+    end
+  end
+end

--- a/spec/database_cleaner/mongo/truncation_mixin_spec.rb
+++ b/spec/database_cleaner/mongo/truncation_mixin_spec.rb
@@ -6,7 +6,7 @@ describe DatabaseCleaner::Mongo::TruncationMixin do
     Class.new do
       include DatabaseCleaner::Mongo::TruncationMixin
 
-      def initialize(database:)
+      def initialize(database)
         @tables_to_exclude = []
         @database = database
       end
@@ -24,7 +24,7 @@ describe DatabaseCleaner::Mongo::TruncationMixin do
       allow(collection).to receive(:remove)
       database = double(collections: [collection])
 
-      klass.new(database: database).clean
+      klass.new(database).clean
 
       expect(collection).to have_received(:remove)
     end
@@ -35,7 +35,7 @@ describe DatabaseCleaner::Mongo::TruncationMixin do
       allow(collection).to receive(:delete_many)
       database = double(collections: [collection])
 
-      klass.new(database: database).clean
+      klass.new(database).clean
 
       expect(collection).to have_received(:delete_many)
     end


### PR DESCRIPTION
The mongo gem removed the `Mongo::VERSION` constant for versions [1.8.x](https://github.com/mongodb/mongo-ruby-driver/blob/1.8.0/VERSION) to 1.12.x till it returned in version 2 and above. For super old versions of mongo, namely [1.7.x](https://github.com/mongodb/mongo-ruby-driver/blob/1.7.1/lib/mongo/version.rb) and below the constant still existed; so we need to check definition of the version constant and check the version number to correctly select the truncation method name. Also, added a spec to exercise the bug that previously existed.