### PR TITLE
Random ids

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -211,6 +211,24 @@ The following option is available for ActiveRecord's `:truncation` and `:deletio
 
 * `:cache_tables` - When set to `true` the list of tables to truncate or delete from will only be read from the DB once, otherwise it will be read before each cleanup run. Set this to `false` if (1) you create and drop tables in your tests, or (2) you change Postgres schemas (`ActiveRecord::Base.connection.schema_search_path`) in your tests (for example, in a multitenancy setup with each tenant in a different Postgres schema). Defaults to `true`.
 
+### Setting random ids when cleaning database
+
+The following is available for ActiveRecord's :truncation strategy _only_ for MySQL and Postgres.
+
+It may be useful to initialize your database with a random value for auto-increment (in case you are using MySQL) or for sequences (in case you are using Postgres).
+Simply call `clean_with` with the `:random_ids` option:
+
+```
+DatabaseCleaner.clean_with :truncation, random_ids: true
+```
+
+`:random_ids` accept the following values:
+
+* `true`: sets a random value for every table
+* an Array: specify the list of tables for which a random value must be set, the other table will be truncated and auto-increment/sequences set to 1
+* a Hash: where the keys are the table names and the values indicate the primary key column name. This is useful for Postgres only when a non-default 'id' name is given to the primary key
+
+Note: `:random_ids` option cannot be used at the same time as `:pre_count`.
 
 ### RSpec Example
 

--- a/lib/database_cleaner/active_record/tools.rb
+++ b/lib/database_cleaner/active_record/tools.rb
@@ -1,0 +1,21 @@
+
+module DatabaseCleaner
+  module ActiveRecord
+    module Tools
+
+      private
+
+      def _filter_tables_from_ids_param(tables, ids)
+        if ids.is_a? TrueClass
+          tables
+        elsif ids.is_a? Array
+          tables & ids.collect(&:to_s)
+        elsif ids.is_a? Hash
+          tables & ids.keys.collect(&:to_s)
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/database_cleaner/generic/truncation.rb
+++ b/lib/database_cleaner/generic/truncation.rb
@@ -2,11 +2,17 @@ module DatabaseCleaner
   module Generic
     module Truncation
       def initialize(opts={})
-        if !opts.empty? && !(opts.keys - [:only, :except, :pre_count, :reset_ids, :cache_tables]).empty?
-          raise ArgumentError, "The only valid options are :only, :except, :pre_count, :reset_ids or :cache_tables. You specified #{opts.keys.join(',')}."
+        if !opts.empty? && !(opts.keys - [:only, :except, :pre_count, :reset_ids, :random_ids, :cache_tables]).empty?
+          raise ArgumentError, "The only valid options are :only, :except, :pre_count, :reset_ids, :random_ids or :cache_tables. You specified #{opts.keys.join(',')}."
         end
         if opts.has_key?(:only) && opts.has_key?(:except)
           raise ArgumentError, "You may only specify either :only or :except.  Doing both doesn't really make sense does it?"
+        end
+        if opts.has_key?(:pre_count) && opts.has_key?(:random_ids)
+          raise ArgumentError, "You may only specify either :pre_count or :random_ids."
+        end
+        if opts.has_key?(:random_ids) && ![TrueClass, Array, Hash].include?(opts[:random_ids].class)
+          raise ArgumentError, "You may only specify true, an Array or a Hash for :random_ids option."
         end
 
         @only = opts[:only]
@@ -14,11 +20,12 @@ module DatabaseCleaner
         @tables_to_exclude += migration_storage_names
         @pre_count = opts[:pre_count]
         @reset_ids = opts[:reset_ids]
+        @random_ids = opts[:random_ids]
         @cache_tables = opts.has_key?(:cache_tables) ? !!opts[:cache_tables] : true
       end
 
       def start
-        #included for compatability reasons, do nothing if you don't need to
+        #included for compatibility reasons, do nothing if you don't need to
       end
 
       def clean

--- a/spec/database_cleaner/active_record/tools_spec.rb
+++ b/spec/database_cleaner/active_record/tools_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'database_cleaner/active_record/tools'
+
+module DatabaseCleaner
+  module ActiveRecord
+    class ExampleTools
+      include ::DatabaseCleaner::ActiveRecord::Tools
+    end
+
+    describe ExampleTools do
+      let(:tools) { ExampleTools.new }
+
+      describe "filter_tables_from_ids_param" do
+        let(:tables) { %w[table1 table2 table3] }
+
+        it "from a true class" do
+          expect(tools.send :_filter_tables_from_ids_param, tables, true).to eq(%w[table1 table2 table3])
+        end
+
+        it "from an array" do
+          expect(tools.send :_filter_tables_from_ids_param, tables, %w[table1 table3]).to eq(%w[table1 table3])
+        end
+
+        it "from a hash" do
+          expect(tools.send :_filter_tables_from_ids_param, tables, table2: 'id', 'table3' => 'key').to eq(%w[table2 table3])
+        end
+
+        it "from something else" do
+          expect(tools.send :_filter_tables_from_ids_param, tables, false).to eq([])
+          expect(tools.send :_filter_tables_from_ids_param, tables, "wrong").to eq([])
+          expect(tools.send :_filter_tables_from_ids_param, tables, :error).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/database_cleaner/active_record/truncation/mysql2_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/mysql2_spec.rb
@@ -32,6 +32,10 @@ module ActiveRecord
       it_behaves_like "an adapter with pre-count truncation" do
         let(:connection) { active_record_mysql2_connection }
       end
+
+      it_behaves_like "an adapter with random-ids truncation" do
+        let(:connection) { active_record_mysql2_connection }
+      end
     end
   end
 end

--- a/spec/database_cleaner/active_record/truncation/mysql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/mysql_spec.rb
@@ -32,6 +32,10 @@ module ActiveRecord
       it_behaves_like "an adapter with pre-count truncation" do
         let(:connection) { active_record_mysql_connection }
       end
+
+      it_behaves_like "an adapter with random-ids truncation" do
+        let(:connection) { active_record_mysql_connection }
+      end
     end
   end
 end

--- a/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
+++ b/spec/database_cleaner/active_record/truncation/postgresql_spec.rb
@@ -70,6 +70,9 @@ module ActiveRecord
         let(:connection) { active_record_pg_connection }
       end
 
+      it_behaves_like "an adapter with random-ids truncation" do
+        let(:connection) { active_record_pg_connection }
+      end
     end
   end
 end

--- a/spec/database_cleaner/active_record/truncation/shared_fast_truncation.rb
+++ b/spec/database_cleaner/active_record/truncation/shared_fast_truncation.rb
@@ -38,3 +38,113 @@ shared_examples_for "an adapter with pre-count truncation" do
     end
   end
 end
+
+shared_examples_for "an adapter with random-ids truncation" do
+  describe "#random_ids_truncate_tables" do
+
+    before do
+      allow(connection).to receive(:rand).with(1000).and_return 123 # Forcing rand() to always return 123
+    end
+
+    context "with :random_ids set true" do
+      before do
+        2.times { User.create }
+      end
+
+      it "truncates the table" do
+        connection.random_ids_truncate_tables(%w[users], :random_ids => true)
+        User.count.should be_zero
+      end
+
+      it "randomly set AUTO_INCREMENT index of table" do
+        User.delete_all
+
+        connection.random_ids_truncate_tables(%w[users]) # true is also the default
+        User.create.id.should eq 1230
+      end
+    end
+
+
+    context "with :reset_ids as an array" do
+      before do
+        2.times { User.create }
+        2.times { ToDo.create }
+      end
+
+      it "truncates all tables" do
+        connection.random_ids_truncate_tables(%w[users to_dos], :random_ids => %w[users])
+        User.count.should be_zero
+        ToDo.count.should be_zero
+      end
+
+      it "only randomize AUTO_INCREMENT index of selected table" do
+        User.delete_all
+        ToDo.delete_all
+
+        connection.random_ids_truncate_tables(%w[users to_dos], :random_ids => %w[users])
+        User.create.id.should eq 1230
+        ToDo.create.key.should eq 1
+      end
+    end
+
+
+    context "with :reset_ids as a hash" do
+      before do
+        2.times { User.create }
+        2.times { ToDo.create }
+      end
+
+      context "truncates all tables" do
+        it "given symbols" do
+          connection.random_ids_truncate_tables(%w[users to_dos], :random_ids => {to_dos: :key})
+          User.count.should be_zero
+          ToDo.count.should be_zero
+        end
+
+        it "given strings" do
+          connection.random_ids_truncate_tables(%w[users to_dos], :random_ids => {'to_dos' => 'key'})
+          User.count.should be_zero
+          ToDo.count.should be_zero
+        end
+      end
+
+      context "only randomize AUTO_INCREMENT index of listed table" do
+        before do
+          User.delete_all
+          ToDo.delete_all
+        end
+
+        it "given symbols" do
+          connection.random_ids_truncate_tables(%w[users to_dos], :random_ids => {to_dos: :key})
+          User.create.id.should eq 1
+          ToDo.create.key.should eq 1230
+        end
+
+        it "given strings" do
+          connection.random_ids_truncate_tables(%w[users to_dos], :random_ids => {'to_dos' => 'key'})
+          User.create.id.should eq 1
+          ToDo.create.key.should eq 1230
+        end
+      end
+    end
+
+
+    context "with :reset_ids set false" do
+      it "truncates the table" do
+        2.times { User.create }
+
+        connection.random_ids_truncate_tables(%w[users], :random_ids => false)
+        User.count.should be_zero
+      end
+
+      it "does not randomize AUTO_INCREMENT index of table" do
+        2.times { User.create }
+        User.delete_all
+
+        connection.random_ids_truncate_tables(%w[users], :random_ids => false)
+
+        User.create.id.should eq 1
+      end
+    end
+  end
+end

--- a/spec/database_cleaner/generic/truncation_spec.rb
+++ b/spec/database_cleaner/generic/truncation_spec.rb
@@ -21,6 +21,10 @@ module ::DatabaseCleaner
       def pre_count?
         !!@pre_count
       end
+
+      def random_ids?
+        !!@random_ids
+      end
     end
 
     class MigrationExample < TruncationExample
@@ -58,12 +62,17 @@ module ::DatabaseCleaner
           expect{ TruncationExample.new {} }.to_not raise_error
         end
 
-        it { expect{ TruncationExample.new( { :a_random_param => "should raise ArgumentError"  } ) }.to     raise_error(ArgumentError) }
-        it { expect{ TruncationExample.new( { :except => "something",:only => "something else" } ) }.to     raise_error(ArgumentError) }
-        it { expect{ TruncationExample.new( { :only   => "something"                           } ) }.to_not raise_error }
-        it { expect{ TruncationExample.new( { :except => "something"                           } ) }.to_not raise_error }
-        it { expect{ TruncationExample.new( { :pre_count => "something"                        } ) }.to_not raise_error }
-        it { expect{ TruncationExample.new( { :reset_ids => "something"                        } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :a_random_param => "should raise ArgumentError"            } ) }.to     raise_error(ArgumentError) }
+        it { expect{ TruncationExample.new( { :except => "something", :only => "something else"          } ) }.to     raise_error(ArgumentError) }
+        it { expect{ TruncationExample.new( { :pre_count => "something", :random_ids => "something else" } ) }.to     raise_error(ArgumentError) }
+        it { expect{ TruncationExample.new( { :random_ids => "something",                                } ) }.to     raise_error(ArgumentError) }
+        it { expect{ TruncationExample.new( { :only   => "something"                                     } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :except => "something"                                     } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :pre_count => "something"                                  } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :reset_ids => "something"                                  } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :random_ids => true                                        } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :random_ids => %w[something]                               } ) }.to_not raise_error }
+        it { expect{ TruncationExample.new( { :random_ids => {some: 'stuff'}                             } ) }.to_not raise_error }
 
         context "" do
           subject { TruncationExample.new( { :only => ["something"] } ) }
@@ -95,6 +104,16 @@ module ::DatabaseCleaner
         context "" do
           subject { TruncationExample.new( { :pre_count => nil } ) }
           its(:pre_count?) { should eq false }
+        end
+
+        context "" do
+          subject { TruncationExample.new( { :random_ids => ["something"] } ) }
+          its(:random_ids?) { should eq true }
+        end
+
+        context "" do
+          subject { TruncationExample.new }
+          its(:random_ids?) { should eq false }
         end
 
         context "" do

--- a/spec/support/active_record/schema_setup.rb
+++ b/spec/support/active_record/schema_setup.rb
@@ -4,6 +4,10 @@ def active_record_load_schema
       t.integer :name
     end
 
+    create_table :to_dos, :primary_key => :key, :force => true do |t|
+      t.integer :name
+    end
+
     create_table :agents, :id => false, :force => true do |t|
       t.integer :name
     end
@@ -11,6 +15,10 @@ def active_record_load_schema
 end
 
 class ::User < ActiveRecord::Base
+end
+
+class ::ToDo < ActiveRecord::Base
+  set_primary_key :key
 end
 
 class ::Agent < ActiveRecord::Base


### PR DESCRIPTION
I sometimes (often ?) mistakenly use a wrong record at the wrong place, and the specs could wrongly be all green only because in the running test all records `id` have the same value : 1. 

This PR is to have DatabaseCleaner to set auto-increment/sequence to a random value when calling `DatabaseCleaner.clean_with`

- Works with MySql and PostgreSql
- Works with truncation only
- Disabled by default (though enabling it by default could be a good idea, but it's time consuming)
- Can be set for all tables or only for specific tables
- Can specify the primary key for each table (useful only for PostgreSal)
- Cannot be used alongside with `:pre_count`

Activated by calling `DatabaseCleaner.clean_with :truncation, random_ids: true`

`random_ids: %w[table1 table2]` would set random auto-increment/sequence to table1 and table2 _only_, all other table would be truncated as usual

`random_ids: {table1: 'id', table2: 'key'}` would set random auto-increment/sequence to table1 and table2 _only_, AND specifying that table2's primary key's name is 'key'. All other table would be truncated as usual