### PR TITLE
Rails 5.1 removes ActiveRecord::Migrator.schema_migrations_table_name…

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -192,7 +192,7 @@ module DatabaseCleaner
           FROM pg_tables
           WHERE
             tablename !~ '_prt_' AND
-            tablename <> '#{::ActiveRecord::Migrator.schema_migrations_table_name}' AND
+            tablename <> '#{::ActiveRecord::SchemaMigration.table_name}' AND
             schemaname = ANY (current_schemas(false))
         _SQL
         rows.collect { |result| result.first }
@@ -257,7 +257,7 @@ module DatabaseCleaner::ActiveRecord
 
     # overwritten
     def migration_storage_names
-      [::ActiveRecord::Migrator.schema_migrations_table_name]
+      [::ActiveRecord::SchemaMigration.table_name]
     end
 
     def cache_tables?


### PR DESCRIPTION
… and replaces it with ActiveRecord::SchemaMigration.table_name (available since Rails 4.0) (fixes #476)