### PR TITLE
Return connection class

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -69,6 +69,7 @@ module DatabaseCleaner
 
       def establish_connection
         ::ActiveRecord::Base.establish_connection(connection_hash)
+        ::ActiveRecord::Base
       end
 
     end

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -181,6 +181,12 @@ my_db:
 
             subject.connection_class
           end
+
+          it "returns the connection class" do
+            ::ActiveRecord::Base.stub(:establish_connection)
+
+            subject.connection_class.should eq ::ActiveRecord::Base
+          end
         end
       end
     end


### PR DESCRIPTION
This method is used in the `#connection_class` method and should return a class after establishing the connection