### PR TITLE
innodb support (mysql 5.6+)

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -54,8 +54,27 @@ module DatabaseCleaner::ActiveRecord
 
     def tables_with_new_rows(connection)
       @db_name ||= connection.instance_variable_get('@config')[:database]
-      result = connection.exec_query("SELECT table_name FROM information_schema.tables WHERE table_schema = '#{@db_name}' AND table_rows > 0")
-      result.map{ |row| row['table_name'] } - ['schema_migrations']
+      stats = table_stats_query(connection, @db_name)
+      if stats != ''
+        connection.exec_query(stats).inject([]) {|all, stat| all << stat['table_name'] if stat['exact_row_count'] > 0; all }
+      else
+        []
+      end
+    end
+
+    def table_stats_query(connection, db_name)
+      if @cache_tables && !@table_stats_query.nil?
+        return @table_stats_query
+      else
+        @table_stats_query = connection.select_values(<<-SQL).join(' UNION ')
+               SELECT CONCAT('SELECT \"', table_name, '\" AS table_name, COUNT(*) AS exact_row_count FROM ', table_name)
+               FROM
+               INFORMATION_SCHEMA.TABLES
+               WHERE
+               table_schema = '#{db_name}'
+               AND table_name <> 'schema_migrations';
+        SQL
+      end
     end
 
     def information_schema_exists? connection


### PR DESCRIPTION
fixes #455

1/ the original algorithm works only on mysql < 5.6 or if myisam engine is enabled. On innodb, deletion strategy isn't reliable at all. We have many test failures because of this bug.
2/ instead of using information_schema COUNT(*) entries from all tables. This is suprisingly much faster (about 30 times) and reliable.
3/ also accessing information_schema is VERY slow, if caching is enabled, we don't have to access information_schema over and over again. It saves some additional time between tests.