### PR TITLE
Fix missing method in deletion

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -72,7 +72,7 @@ module DatabaseCleaner::ActiveRecord
                INFORMATION_SCHEMA.TABLES
                WHERE
                table_schema = '#{db_name}'
-               AND table_name <> '#{migration_table_name}';
+               AND table_name <> '#{::DatabaseCleaner::ActiveRecord::Base.migration_table_name}';
         SQL
       end
     end


### PR DESCRIPTION
`migration_table_name` is not defined in this module