### PR TITLE
Use the right ActiveRecord::Base module.

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -68,7 +68,7 @@ module DatabaseCleaner
       def self.exclusion_condition(column_name)
         result = " #{column_name} <> '#{::DatabaseCleaner::ActiveRecord::Base.migration_table_name}' "
         if ::ActiveRecord::VERSION::MAJOR >= 5
-          result += " AND #{column_name} <> '#{ActiveRecord::Base.internal_metadata_table_name}' "
+          result += " AND #{column_name} <> '#{::ActiveRecord::Base.internal_metadata_table_name}' "
         end
         result
       end


### PR DESCRIPTION
Hey @etagwerker, 

This PR fixes a problem with database_cleaner and Rails 5. The module name syntax for `ActiveRecord::Base` in the exclusion condition was incorrect. 

Please check it out, thanks! 