### PR TITLE
Fix ActiveRecord::Base.internal_metadata_table_name lookup

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -68,7 +68,7 @@ module DatabaseCleaner
       def self.exclusion_condition(column_name)
         result = " #{column_name} <> '#{::DatabaseCleaner::ActiveRecord::Base.migration_table_name}' "
         if ::ActiveRecord::VERSION::MAJOR >= 5
-          result += " AND #{column_name} <> '#{ActiveRecord::Base.internal_metadata_table_name}' "
+          result += " AND #{column_name} <> '#{::ActiveRecord::Base.internal_metadata_table_name}' "
         end
         result
       end


### PR DESCRIPTION
Without this, `ActiveRecord::Base.internal_metadata_table_name` resolves to the `DatabaseCleaner::ActiveRecord::Base`, which doesn't have that method. This means trying to run with a truncation strategy on Rails >= 5 results in the following error:

```
NoMethodError:
    undefined method `internal_metadata_table_name' for DatabaseCleaner::ActiveRecord::Base:Module
```

Phew!