### PR TITLE
Quote table name in ActiveRecord::SelectiveTruncation#table_stats_query

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -66,8 +66,9 @@ module DatabaseCleaner::ActiveRecord
       if @cache_tables && !@table_stats_query.nil?
         return @table_stats_query
       else
+        quote_start, quote_end = connection.quote_table_name('T').split('T')
         @table_stats_query = connection.select_values(<<-SQL).join(' UNION ')
-               SELECT CONCAT('SELECT \"', table_name, '\" AS table_name, COUNT(*) AS exact_row_count FROM ', table_name)
+               SELECT CONCAT('SELECT \"', table_name, '\" AS table_name, COUNT(*) AS exact_row_count FROM #{quote_start}', table_name, '#{quote_end}')
                FROM
                INFORMATION_SCHEMA.TABLES
                WHERE


### PR DESCRIPTION
Kind of patchy, maybe someone can think of a better way.

My tables need quoting, and there's a change in 1.6 that didn't quote. It's a query generated with a string inside the query, so quoting is not straight forward (`table_name` is not a Ruby variable).