### PR TITLE
Update README to indicate support for Sequel deletion strategy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ Here is an overview of the strategies supported for each library:
       <td> Sequel</td>
       <td> <b>Yes</b></td>
       <td> Yes</td>
-      <td> No</td>
+      <td> Yes</td>
     </tr>
     <tr>
       <td>Redis</td>


### PR DESCRIPTION
The documentation of using database cleaner with sequel in deletion mode is confusing.
The code supports this:
https://github.com/DatabaseCleaner/database_cleaner/blob/master/lib/database_cleaner/sequel/deletion.rb

closes #492
