### PR TITLE
Fix Mongo truncation by improving Mongo version detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
+source "https://rubygems.org"
+
 gemspec

--- a/lib/database_cleaner/mongo/truncation_mixin.rb
+++ b/lib/database_cleaner/mongo/truncation_mixin.rb
@@ -18,8 +18,7 @@ module DatabaseCleaner
       end
 
       def truncate_method_name
-        # This constant only exists in the 2.x series.
-        defined?(::Mongo::VERSION) ? :delete_many : :remove
+        defined?(::Mongo::VERSION) && ::Mongo::VERSION >= "2" ? :delete_many : :remove
       end
     end
   end


### PR DESCRIPTION
The `Mongo::VERSION` constant does not just exist since version 2.0 [as advertised](https://github.com/mongodb/mongo-ruby-driver/blob/v2.5.0.beta/lib/mongo/version.rb#L19-L20). It actually existed in all patch versions of 1.6 and [1.7](https://github.com/mongodb/mongo-ruby-driver/blob/1.7.1/lib/mongo/version.rb#L2) as well.