### PR TITLE
Get tests running on MySQL 5.7.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    database_cleaner (1.6.3)
+    database_cleaner (1.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -283,4 +283,4 @@ DEPENDENCIES
   tzinfo
 
 BUNDLED WITH
-   1.15.0
+   1.16.1

--- a/spec/support/active_record/mysql2_setup.rb
+++ b/spec/support/active_record/mysql2_setup.rb
@@ -1,7 +1,6 @@
 require 'support/active_record/database_setup'
 require 'support/active_record/schema_setup'
 
-
 module MySQL2Helper
   puts "Active Record #{ActiveRecord::VERSION::STRING}, mysql2"
 
@@ -24,6 +23,7 @@ module MySQL2Helper
   end
 
   def active_record_mysql2_setup
+    patch_mysql2_adapter
     create_db
     establish_connection
     active_record_load_schema
@@ -31,6 +31,11 @@ module MySQL2Helper
 
   def active_record_mysql2_connection
     ActiveRecord::Base.connection
+  end
+
+  def patch_mysql2_adapter
+    # remove DEFAULT NULL from column definition, which is an error on primary keys in MySQL 5.7.3+
+    ActiveRecord::ConnectionAdapters::Mysql2Adapter::NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
   end
 end
 

--- a/spec/support/active_record/mysql_setup.rb
+++ b/spec/support/active_record/mysql_setup.rb
@@ -23,6 +23,7 @@ module MySQLHelper
   end
 
   def active_record_mysql_setup
+    patch_mysql_adapter
     create_db
     establish_connection
     active_record_load_schema
@@ -30,6 +31,11 @@ module MySQLHelper
 
   def active_record_mysql_connection
     ActiveRecord::Base.connection
+  end
+
+  def patch_mysql_adapter
+    # remove DEFAULT NULL from column definition, which is an error on primary keys in MySQL 5.7.3+
+    ActiveRecord::ConnectionAdapters::MysqlAdapter::NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
   end
 end
 


### PR DESCRIPTION
I was unable to run the MySQL tests on my local machine, getting the following error on every spec:

```
All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead: CREATE TABLE `users` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY, `name` int(11)) ENGINE=InnoDB
```

What's happening is both `mysql` and `mysql2` adapters generate SQL that sets the primary key column's default to NULL. A primary key being NULL doesn't really make any sense, but this invocation was silently ignored until MySQL 5.7.3, when it became the above error. See https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-3.html . Normally, we could just bump the adapter gems to fix this, but the `mysql` gem is no longer maintained, and we can't upgrade the `mysql2` adapter for dependency hell reasons.

Instead, I have worked around this issue by patching both adapters in the test code.

