### PR TITLE
Fix race conditions in moped and mongo tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    database_cleaner (1.6.3)
+    database_cleaner (1.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -283,4 +283,4 @@ DEPENDENCIES
   tzinfo
 
 BUNDLED WITH
-   1.15.0
+   1.16.1

--- a/lib/database_cleaner/moped/truncation_base.rb
+++ b/lib/database_cleaner/moped/truncation_base.rb
@@ -13,6 +13,7 @@ module DatabaseCleaner
         else
           collections.each { |c| session[c].find.remove_all unless @tables_to_exclude.include?(c) }
         end
+        wait_for_removals_to_finish
         true
       end
 
@@ -35,6 +36,9 @@ module DatabaseCleaner
         end
       end
 
+      def wait_for_removals_to_finish
+        session.command(getlasterror: 1)
+      end
     end
   end
 end

--- a/spec/database_cleaner/mongo/truncation_spec.rb
+++ b/spec/database_cleaner/mongo/truncation_spec.rb
@@ -24,7 +24,8 @@ module DatabaseCleaner
         # I had to add this sanity_check garbage because I was getting non-determinisc results from mongo at times..
         # very odd and disconcerting...
         expected_counts.each do |model_class, expected_count|
-          model_class.count.should eq(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{model_class.count}"
+          actual_count = model_class.count
+          actual_count.should eq(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{actual_count}"
         end
       end
 

--- a/spec/database_cleaner/mongo_mapper/truncation_spec.rb
+++ b/spec/database_cleaner/mongo_mapper/truncation_spec.rb
@@ -25,7 +25,8 @@ module DatabaseCleaner
         sanity_check = expected_counts.delete(:sanity_check)
         begin
           expected_counts.each do |model_class, expected_count|
-            model_class.count.should eq(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{model_class.count}"
+            actual_count = model_class.count
+            actual_count.should eq(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{actual_count}"
           end
         rescue RSpec::Expectations::ExpectationNotMetError => e
           raise !sanity_check ? e : RSpec::ExpectationNotMetError::ExpectationNotMetError.new("SANITY CHECK FAILURE! This should never happen here: #{e.message}")

--- a/spec/database_cleaner/moped/truncation_spec.rb
+++ b/spec/database_cleaner/moped/truncation_spec.rb
@@ -27,7 +27,8 @@ module DatabaseCleaner
         # I had to add this sanity_check garbage because I was getting non-determinisc results from mongo at times..
         # very odd and disconcerting...
         expected_counts.each do |model_class, expected_count|
-          model_class.count.should eq(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{model_class.count}"
+          actual_count = model_class.count
+          actual_count.should eq(expected_count), "#{model_class} expected to have a count of #{expected_count} but was #{actual_count}"
         end
       end
 

--- a/spec/database_cleaner/moped/truncation_spec.rb
+++ b/spec/database_cleaner/moped/truncation_spec.rb
@@ -21,6 +21,7 @@ module DatabaseCleaner
 
       after(:each) do
         @session.drop
+        @session.command(getlasterror: 1)
       end
 
       def ensure_counts(expected_counts)


### PR DESCRIPTION
As noted in #522, there is an unstable spec in `spec/database_cleaner/moped/truncation_spec.rb:57` that sometimes fails with:

```
MopedTest::Widget expected to have a count of 0 but was 0
```

This is caused by two race conditions:
1. A race condition in the moped adapter where the truncation command can sometimes return before the truncations are complete.
2. A race condition in the assertion where the count is calculated twice, the first time before the truncations are complete, tripping the assertion, and the second time after the truncations are complete, resulting in the nonsensical error message.

Both have been fixed.