### PR TITLE
Speedup Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9.3
@@ -10,16 +11,23 @@ script:
 gemfile:
   - Gemfile
 before_install:
-  - gem install bundler -v 1.14.6
-  # install Neo4j locally:
-  - wget dist.neo4j.org/neo4j-community-2.3.3-unix.tar.gz
-  - tar -xzf neo4j-community-2.3.3-unix.tar.gz
-  - sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-2.3.3/conf/neo4j-server.properties
-  - neo4j-community-2.3.3/bin/neo4j start
+  - | # cached install of Neo4j locally:
+    if [ ! -d neo4j-community-2.3.3/bin ];
+    then
+      wget dist.neo4j.org/neo4j-community-2.3.3-unix.tar.gz;
+      tar -xzf neo4j-community-2.3.3-unix.tar.gz;
+      sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-2.3.3/conf/neo4j-server.properties;
+    fi
 before_script:
+  - neo4j-community-2.3.3/bin/neo4j start
   - mysql -e 'create database database_cleaner_test;'
   - psql -c 'create database database_cleaner_test;' -U postgres
   - cp db/sample.config.yml db/config.yml
 services:
   - redis-server
   - mongodb
+cache:
+  bundler: true
+  directories:
+    - neo4j-community-2.3.3
+


### PR DESCRIPTION
A few tricks:
1. Run using docker with `sudo: false` for faster startup
2. Cache the result of downloading and extracting neo4j. Even though this is downloading more bytes, this is faster because the cached server is much faster to reach (same network) than the neo4j server.
3. Cache the result of running bundler