### PR TITLE
Fix moped race condition

### DIFF
--- a/lib/database_cleaner/moped/base.rb
+++ b/lib/database_cleaner/moped/base.rb
@@ -32,7 +32,7 @@ module DatabaseCleaner
       private
 
       def session
-        ::Moped::Session.new([host], database: db)
+        @session ||= ::Moped::Session.new([host], database: db)
       end
     end
   end


### PR DESCRIPTION
Fixes moped race condition mentioned in #550. I think the issue was that a new connection was being created each time the adapter communicated with the database, thereby creating the possibility that `getLastError` would return before the truncate command did, resulting in a cleaning that returned before it completed, and thus finally, the flaky test.

I'm not 100% on this exact diagnosis -- its just a hypothesis -- but the flake does appear to be gone as a result of this patch:
1. Saw the failure after running the spec 296 times.
2. Applied the patch.
3. Didn't see the failure after running the spec 3128 times (I cancelled the loop).
4. Reverted the patch.
5. Saw the failure again after running the spec 413 times.

Good enough for me!