### PR TITLE
Refactor Null Strategy to use an instance instead of a singleton

### DIFF
--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -1,5 +1,6 @@
 require 'database_cleaner/null_strategy'
 require 'database_cleaner/safeguard'
+
 module DatabaseCleaner
   class Base
     include Comparable
@@ -75,7 +76,7 @@ module DatabaseCleaner
     end
 
     def strategy
-      @strategy ||= NullStrategy
+      @strategy ||= NullStrategy.new
     end
 
     def orm=(desired_orm)

--- a/lib/database_cleaner/null_strategy.rb
+++ b/lib/database_cleaner/null_strategy.rb
@@ -1,18 +1,18 @@
 module DatabaseCleaner
   class NullStrategy
-    def self.start
+    def start
       # no-op
     end
     
-     def self.db=(connection)
-       # no-op
-     end
+    def db=(connection)
+      # no-op
+    end
      
-    def self.clean
+    def clean
       # no-op
     end
 
-    def self.cleaning(&block)
+    def cleaning(&block)
       # no-op
       yield
     end

--- a/spec/database_cleaner/base_spec.rb
+++ b/spec/database_cleaner/base_spec.rb
@@ -380,7 +380,7 @@ module DatabaseCleaner
       subject { ::DatabaseCleaner::Base.new :a_orm }
 
       it "returns a null strategy when strategy is not set and undetectable" do
-        expect(subject.strategy).to eq DatabaseCleaner::NullStrategy
+        expect(subject.strategy).to be_a(DatabaseCleaner::NullStrategy)
       end
 
       it "returns the set strategy" do

--- a/spec/database_cleaner/null_strategy_spec.rb
+++ b/spec/database_cleaner/null_strategy_spec.rb
@@ -3,23 +3,23 @@ require "database_cleaner/null_strategy"
 module DatabaseCleaner
   RSpec.describe NullStrategy do
     it 'responds to .start' do
-      expect { NullStrategy.start }.not_to raise_error
+      expect { subject.start }.not_to raise_error
     end
 
     it 'responds to .clean' do
-      expect { NullStrategy.clean }.not_to raise_error
+      expect { subject.clean }.not_to raise_error
     end
 
     describe '.cleaning' do
       it 'fails without a block' do
-        expect { NullStrategy.cleaning }.to raise_error(LocalJumpError)
+        expect { subject.cleaning }.to raise_error(LocalJumpError)
       end
 
       it 'no-ops with a block' do
         effect = double
         expect(effect).to receive(:occur).once
 
-        NullStrategy.cleaning do
+        subject.cleaning do
           effect.occur
         end
       end


### PR DESCRIPTION
It's well-established that instances are generally preferable to singletons in an OO environment, so this is a fairly obvious and simple refactoring. However, there is the question of whether or not it breaks the public API.

The README says:
```
Database Cleaner also includes a null strategy (that does no cleaning at all) which can be used with any ORM library. You can also explicitly use it by setting your strategy to `nil`.
```

I think this implies that it would be okay, but perhaps we should play it safe, deprecate as part of v1.9.0,  then wait until we release v2.0.0 to make the change. Thoughts?