### PR TITLE
Add version and semver-compatibility badges

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner)
 [![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner)
+![Gem Version](https://badge.fury.io/rb/database_cleaner.svg)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=database_cleaner&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=database_cleaner&package-manager=bundler&version-scheme=semver)
 
 Database Cleaner is a set of strategies for cleaning your database in Ruby.
 


### PR DESCRIPTION
First up, thanks for Database Cleaner!

Adds a SemVer compatibility badge that displays the percentage of CI runs that pass when updating Database Cleaner between SemVer compatible versions. Data comes from Dependabot (disclosure: I built it). I've also added a gem-version badge, which should make it easier for people adding Database Cleaner to their Gemfile (I always end up checking for one / looking on Rubygems).

Here's what the badges look like:

![Gem Version](https://badge.fury.io/rb/database_cleaner.svg) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=database_cleaner&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=database_cleaner&package-manager=bundler&version-scheme=semver)

Any feedback super appreciated!