### PR TITLE
Refactor MySQL deletion strategy (AR)

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -56,7 +56,7 @@ module DatabaseCleaner::ActiveRecord
       @db_name ||= connection.instance_variable_get('@config')[:database]
       stats = table_stats_query(connection, @db_name)
       if stats != ''
-        connection.exec_query(stats).inject([]) {|all, stat| all << stat['table_name'] if stat['has_rows'] == 1; all }
+        connection.select_values(stats)
       else
         []
       end
@@ -73,9 +73,9 @@ module DatabaseCleaner::ActiveRecord
           AND #{::DatabaseCleaner::ActiveRecord::Base.exclusion_condition('table_name')};
         SQL
         queries = tables.map do |table|
-          "SELECT #{connection.quote(table)} AS table_name, COUNT(*) > 0 AS has_rows FROM #{connection.quote_table_name(table)}"
+          "(SELECT #{connection.quote(table)} FROM #{connection.quote_table_name(table)} LIMIT 1)"
         end
-        @table_stats_query = queries.join(' UNION ')
+        @table_stats_query = queries.join(' UNION ALL ')
       end
     end
 

--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -53,8 +53,7 @@ module DatabaseCleaner::ActiveRecord
     end
 
     def tables_with_new_rows(connection)
-      @db_name ||= connection.instance_variable_get('@config')[:database]
-      stats = table_stats_query(connection, @db_name)
+      stats = table_stats_query(connection)
       if stats != ''
         connection.select_values(stats)
       else
@@ -62,14 +61,14 @@ module DatabaseCleaner::ActiveRecord
       end
     end
 
-    def table_stats_query(connection, db_name)
+    def table_stats_query(connection)
       if @cache_tables && !@table_stats_query.nil?
         return @table_stats_query
       else
         tables = connection.select_values(<<-SQL)
           SELECT table_name
           FROM information_schema.tables
-          WHERE table_schema = '#{db_name}'
+          WHERE table_schema = database()
           AND #{::DatabaseCleaner::ActiveRecord::Base.exclusion_condition('table_name')};
         SQL
         queries = tables.map do |table|

--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -62,20 +62,22 @@ module DatabaseCleaner::ActiveRecord
     end
 
     def table_stats_query(connection)
-      if @cache_tables && !@table_stats_query.nil?
-        return @table_stats_query
-      else
-        tables = connection.select_values(<<-SQL)
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_schema = database()
-          AND #{::DatabaseCleaner::ActiveRecord::Base.exclusion_condition('table_name')};
-        SQL
-        queries = tables.map do |table|
-          "(SELECT #{connection.quote(table)} FROM #{connection.quote_table_name(table)} LIMIT 1)"
-        end
-        @table_stats_query = queries.join(' UNION ALL ')
+      @table_stats_query ||= build_table_stats_query(connection)
+    ensure
+      @table_stats_query = nil unless @cache_tables
+    end
+
+    def build_table_stats_query(connection)
+      tables = connection.select_values(<<-SQL)
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = database()
+        AND #{::DatabaseCleaner::ActiveRecord::Base.exclusion_condition('table_name')};
+      SQL
+      queries = tables.map do |table|
+        "(SELECT #{connection.quote(table)} FROM #{connection.quote_table_name(table)} LIMIT 1)"
       end
+      queries.join(' UNION ALL ')
     end
 
     def information_schema_exists? connection


### PR DESCRIPTION
While trying to understand the special deletion strategy for MySQL, I refactored code and DB queries. Fixes #516 as well.

For the future: There appears to be some overlap with the truncation strategy. What is effectively done here is a `pre_count` for deletion.