### PR TITLE
Allow postgres:///dbname as a local url

### DIFF
--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -39,7 +39,7 @@ module DatabaseCleaner
 
 
     class RemoteDatabaseUrl
-      LOCAL = %w(localhost .local 127.0.0.1 sqlite3:)
+      LOCAL = %w(localhost 127.0.0.1)
 
       def run
         raise Error::RemoteDatabaseUrl if !skip? && given?
@@ -52,7 +52,16 @@ module DatabaseCleaner
         end
 
         def remote?(url)
-          url && !LOCAL.any? { |str| url.include?(str) }
+          return false unless url
+
+          parsed = URI.parse(url)
+          return false if parsed.scheme == 'sqlite3:'
+
+          host = parsed.host
+          return false unless host
+          return false if LOCAL.include?(host)
+          return false if host.end_with? '.local'
+          true
         end
 
         def skip?

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -21,6 +21,14 @@ module DatabaseCleaner
         end
       end
 
+      describe 'to a local, empty-host url' do
+        let(:database_url) { 'postgres:///' }
+
+        it 'does not raise' do
+          expect { cleaner.start }.to_not raise_error
+        end
+      end
+
       describe 'to a local tld url' do
         let(:database_url) { 'postgres://postgres.local' }
 


### PR DESCRIPTION
Hi, I updated today and was surprised (and a little worried at first) that I was about to clean a remote database. It turns out I was using a style of DATABASE_URL that wasn't considered local. This patch adds that, and also tightens down the checks to actually look at the host (or protocol) instead of those appearing somewhere in the string.