### PR TITLE
Fix MySQL deprecation warnings with Rails 5

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -27,7 +27,11 @@ module DatabaseCleaner
 
       def database_cleaner_table_cache
         # the adapters don't do caching (#130) but we make the assumption that the list stays the same in tests
-        @database_cleaner_tables ||= ::ActiveRecord::VERSION::MAJOR >= 5 ? data_sources : tables
+        @database_cleaner_tables ||= database_tables
+      end
+
+      def database_tables
+        ::ActiveRecord::VERSION::MAJOR >= 5 ? data_sources : tables
       end
 
       def truncate_table(table_name)
@@ -243,7 +247,7 @@ module DatabaseCleaner::ActiveRecord
     private
 
     def tables_to_truncate(connection)
-      tables_in_db = cache_tables? ? connection.database_cleaner_table_cache : connection.tables
+      tables_in_db = cache_tables? ? connection.database_cleaner_table_cache : connection.database_tables
       to_reject = (@tables_to_exclude + connection.database_cleaner_view_cache)
       (@only || tables_in_db).reject do |table|
         if ( m = table.match(/([^.]+)$/) )


### PR DESCRIPTION
When the truncation strategy is used with Rails 5, we see
the deprecation message:

```
DEPRECATION WARNING: #tables currently returns both tables and
views. This behavior is deprecated and will be changed with Rails 5.1 to
only return tables. Use #data_sources instead.
```