### PR TITLE
Use database_version in PostgreSQLAdapter when available.

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -129,16 +129,20 @@ module DatabaseCleaner
     end
 
     module PostgreSQLAdapter
-      def db_version
-        @db_version ||= postgresql_version
+      def database_version
+        if defined?(:super)
+          super
+        else
+          postgresql_version
+        end
       end
 
       def cascade
-        @cascade ||= db_version >=  80200 ? 'CASCADE' : ''
+        @cascade ||= database_version >=  80200 ? 'CASCADE' : ''
       end
 
       def restart_identity
-        @restart_identity ||= db_version >=  80400 ? 'RESTART IDENTITY' : ''
+        @restart_identity ||= database_version >=  80400 ? 'RESTART IDENTITY' : ''
       end
 
       def truncate_table(table_name)


### PR DESCRIPTION
https://github.com/rails/rails/commit/1c6e508ade793b5f2676e9218ab2f4cc9474f9ce#diff-cc31fc1dd1e78db64638200f710b2f59L427 removes `postgresql_version` method in favor of `database_version`.

My change selects the one available.

I have filled in also rails pull request to fix this on their side - https://github.com/rails/rails/pull/35907. Let's wait unless that one is decided.