### PR TITLE
active_record/truncation.rb: Disable `RESTART IDENTITY on CoackroachDB

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -129,6 +129,10 @@ module DatabaseCleaner
     end
 
     module PostgreSQLAdapter
+      def cockroachdb?
+        @coackroachdb ||= adapter_name == 'CockroachDB'
+      end
+
       def db_version
         @db_version ||= postgresql_version
       end
@@ -138,7 +142,7 @@ module DatabaseCleaner
       end
 
       def restart_identity
-        @restart_identity ||= db_version >=  80400 ? 'RESTART IDENTITY' : ''
+        @restart_identity ||= db_version >= 80400 && !cockroachdb? ? 'RESTART IDENTITY' : ''
       end
 
       def truncate_table(table_name)


### PR DESCRIPTION
Coackroach DB doesn't use incremental sequence for row ids hence the `RESTART IDENTITY` bit isn't supported. This adds a very simple test to disable it and make the truncation strategy works with cockroachdb

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>