### PR TITLE
Use auto savepoint for transactions

### DIFF
--- a/lib/database_cleaner/sequel/transaction.rb
+++ b/lib/database_cleaner/sequel/transaction.rb
@@ -19,7 +19,7 @@ module DatabaseCleaner
         @fibers ||= []
         db = self.db
         f = Fiber.new do
-          db.transaction(:rollback => :always, :savepoint => true) do
+          db.transaction(:rollback => :always, :savepoint => true, :auto_savepoint => true) do
             Fiber.yield
           end
         end
@@ -33,7 +33,7 @@ module DatabaseCleaner
       end
 
       def cleaning
-        self.db.transaction(:rollback => :always, :savepoint => true) { yield }
+        self.db.transaction(:rollback => :always, :savepoint => true, :auto_savepoint => true) { yield }
       end
     end
   end


### PR DESCRIPTION
Using `auto_savepoint` for transactions allows any inner transactions (defined by tested code) to be rolled back independently, and will also automatically catch `Sequel::Rollback` exceptions, as would be the case if no transactions were used. Any code that relies on transactions will remain working as expected in the tests.