### PR TITLE
Refactoring and deprecation

### DIFF
--- a/spec/database_cleaner/configuration_spec.rb
+++ b/spec/database_cleaner/configuration_spec.rb
@@ -1,5 +1,4 @@
 module ArrayHelper
-
   def zipmap(array, vals)
     Hash[*(array.zip(vals).flatten)]
   end
@@ -11,7 +10,6 @@ module DatabaseCleaner
     # hackey, hack.. connections needs to stick around until I can properly deprecate the API
     def connections_stub(array)
       @cleaners = ArrayHelper.zipmap((1..array.size).to_a, array)
-      @connections = array
     end
   end
 end


### PR DESCRIPTION
Now that we've extracted the adapter gems, its time to start making life a little bit better for ourselves, by cleaning up internals, and paving the way for 2.0 with deprecations. Turns out I had this branch all ready to go!

Notable changes:
* Extract autodetection bits into `DatabaseCleaner::ORMAutodetector` and deprecate them for easy removal in 2.0
* Deprecate unnecessarily-public methods that were only used internally so we can privatize them in 2.0
* Rename `DatabaseCleaner.connections` to the more accurate `DatabaseCleaner.cleaners` and deprecate the old method
* Extract `DatabaseCleaner::Cleaners` container object to encapsulate knowledge of currently loaded cleaners
* Misc refactoring