### PR TITLE
Update documentation for new adapter gems

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,48 +30,34 @@ group :test do
 end
 ```
 
-## Supported Databases, Libraries and Strategies
+## List of adapters
 
-Here is an overview of the strategies supported for each ORM:
+Here is an overview of the databases and ORMs supported by each adapter:
 
-Gem | ORM | Truncation | Transaction | Deletion
---- | --- | ---------- | ----------- | --------
-[database_cleaner-active_record](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-active_record) | ActiveRecord | Yes | **Yes** | Yes
-[database_cleaner-data_mapper](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-data_mapper) | DataMapper | Yes | **Yes** | No
-[database_cleaner-couch_potato](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-couch_potato) | CouchPotato | **Yes** | No | No
-[database_cleaner-mongo](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongo) | Mongo | **Yes** | No | No
-[database_cleaner-mongo_mapper](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongo_mapper) | MongoMapper | **Yes** | No | No
-[database_cleaner-mongoid](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongoid) | Mongoid | **Yes** | No | No
-[database_cleaner-moped](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-moped) | Moped | **Yes** | No | No
-[database_cleaner-sequel](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-sequel) | Sequel | **Yes** | Yes | Yes
-[database_cleaner-redis](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-redis) | Redis | **Yes** | No | No
-[database_cleaner-ohm](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-ohm) | Ohm | **Yes** | No | No
-[database_cleaner-neo4j](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-neo4j) | Neo4j | Yes | **Yes** | Yes
+MySQL, PostgreSQL, SQLite, etc
+* [database_cleaner-active_record](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-active_record)
+* [database_cleaner-sequel](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-sequel)
+* [database_cleaner-data_mapper](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-data_mapper)
 
-(Default strategy for each library is denoted in bold)
+CouchDB
+* [database_cleaner-couch_potato](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-couch_potato)
 
-Database Cleaner also includes a `null` strategy (that does no cleaning at all) which can be used with any ORM library.
-You can also explicitly use it by setting your strategy to `nil`.
+MongoDB
+ * [database_cleaner-mongoid](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongoid)
+ * [database_cleaner-mongo_mapper](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongo_mapper)
+ * [database_cleaner-moped](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-moped)
+ * [database_cleaner-mongo](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongo)
+
+Redis
+ * [database_cleaner-redis](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-redis)
+ * [database_cleaner-ohm](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-ohm)
+
+Neo4j
+ * [database_cleaner-neo4j](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-neo4j)
 
 More details on available configuration options can be found in the README for the specific adapter gem that you're using.
 
 For support or to discuss development please use the [Google Group](http://groups.google.com/group/database_cleaner).
-
-## What strategy is fastest?
-
-For the SQL libraries the fastest option will be to use `:transaction` as transactions are simply rolled back. If you can use this strategy you should. However, if you wind up needing to use multiple database connections in your tests (i.e. your tests run in a different process than your application) then using this strategy becomes a bit more difficult. You can get around the problem a number of ways.
-
-One common approach is to force all processes to use the same database connection ([common ActiveRecord hack](http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/)) however this approach has been reported to result in non-deterministic failures.
-
-Another approach is to have the transactions rolled back in the application's process and relax the isolation level of the database (so the tests can read the uncommitted transactions).
-
-An easier, but slower, solution is to use the `:truncation` or `:deletion` strategy.
-
-So what is fastest out of `:deletion` and `:truncation`? Well, it depends on your table structure and what percentage of tables you populate in an average test. The reasoning is out of the scope of this README but here is a [good SO answer on this topic for Postgres](http://stackoverflow.com/questions/11419536/postgresql-truncation-speed/11423886#11423886).
-
-Some people report much faster speeds with `:deletion` while others say `:truncation` is faster for them. The best approach therefore is it try all options on your test suite and see what is faster.
-
-If you are using ActiveRecord then take a look at the [additional options](#additional-activerecord-options-for-truncation) available for `:truncation`.
 
 ## How to use
 
@@ -129,6 +115,27 @@ DatabaseCleaner.strategy = :transaction
 
 # then make the DatabaseCleaner.start and DatabaseCleaner.clean calls appropriately
 ```
+
+## What strategy is fastest?
+
+For the SQL libraries the fastest option will be to use `:transaction` as transactions are simply rolled back. If you can use this strategy you should. However, if you wind up needing to use multiple database connections in your tests (i.e. your tests run in a different process than your application) then using this strategy becomes a bit more difficult. You can get around the problem a number of ways.
+
+One common approach is to force all processes to use the same database connection ([common ActiveRecord hack](http://blog.plataformatec.com.br/2011/12/three-tips-to-improve-the-performance-of-your-test-suite/)) however this approach has been reported to result in non-deterministic failures.
+
+Another approach is to have the transactions rolled back in the application's process and relax the isolation level of the database (so the tests can read the uncommitted transactions).
+
+An easier, but slower, solution is to use the `:truncation` or `:deletion` strategy.
+
+So what is fastest out of `:deletion` and `:truncation`? Well, it depends on your table structure and what percentage of tables you populate in an average test. The reasoning is out of the scope of this README but here is a [good SO answer on this topic for Postgres](http://stackoverflow.com/questions/11419536/postgresql-truncation-speed/11423886#11423886).
+
+Some people report much faster speeds with `:deletion` while others say `:truncation` is faster for them. The best approach therefore is it try all options on your test suite and see what is faster.
+
+If you are using ActiveRecord then take a look at the [additional options](#additional-activerecord-options-for-truncation) available for `:truncation`.
+
+Database Cleaner also includes a `null` strategy (that does no cleaning at all) which can be used with any ORM library.
+You can also explicitly use it by setting your strategy to `nil`.
+
+## Test Framework Examples
 
 ### RSpec Example
 

--- a/README.markdown
+++ b/README.markdown
@@ -369,17 +369,6 @@ to one of the values specified in the url whitelist like so:
 DatabaseCleaner.url_whitelist = ['postgres://postgres@localhost', 'postgres://foo@bar']
 ```
 
-## Debugging
-
-In rare cases DatabaseCleaner will encounter errors that it will log.  By default it uses STDOUT set to the ERROR level but you can configure this to use whatever Logger you desire.
-
-Here's an example of using the `Rails.logger` in `env.rb`:
-
-```ruby
-DatabaseCleaner.logger = Rails.logger
-```
-
-
 ## COPYRIGHT
 
 See [LICENSE] for details.

--- a/README.markdown
+++ b/README.markdown
@@ -73,10 +73,6 @@ Some people report much faster speeds with `:deletion` while others say `:trunca
 
 If you are using ActiveRecord then take a look at the [additional options](#additional-activerecord-options-for-truncation) available for `:truncation`.
 
-## Dependencies
-
-Because database_cleaner supports multiple ORMs, it doesn't make sense to include all the dependencies for each one in the gemspec. However, the DataMapper adapter does depend on dm-transactions. Therefore, if you use DataMapper, you must include dm-transactions in your Gemfile/bundle/gemset manually.
-
 ## How to use
 
 ```ruby

--- a/README.markdown
+++ b/README.markdown
@@ -3,17 +3,30 @@
 [![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner)
 [![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner)
 
-Database Cleaner is a set of strategies for cleaning your database in Ruby.
+Database Cleaner is a set of gems containing strategies for cleaning your database in Ruby.
 
 The original use case was to ensure a clean state during tests.
 Each strategy is a small amount of code but is code that is usually needed in any ruby app that is testing with a database.
 
 ## Gem Setup
 
+Instead of using the `database_cleaner` gem directly, each ORM has its own gem. Most projects will only need the `database_cleaner-active_record` gem:
+
 ```ruby
 # Gemfile
 group :test do
-  gem 'database_cleaner'
+  gem 'database_cleaner-active_record'
+end
+```
+
+If you are using multiple ORMs, just load multiple gems:
+
+
+```ruby
+# Gemfile
+group :test do
+  gem 'database_cleaner-active_record'
+  gem 'database_cleaner-redis'
 end
 ```
 
@@ -21,97 +34,21 @@ end
 
 ActiveRecord, DataMapper, Sequel, MongoMapper, Mongoid, CouchPotato, Ohm and Redis are supported.
 
-Here is an overview of the strategies supported for each library:
+Here is an overview of the strategies supported for each ORM:
 
-<table>
-  <tbody>
-    <tr>
-      <th>ORM</th>
-      <th>Truncation</th>
-      <th>Transaction</th>
-      <th>Deletion</th>
-    </tr>
-    <tr>
-      <td> ActiveRecord </td>
-      <td> Yes</td>
-      <td> <b>Yes</b></td>
-      <td> Yes</td>
-    </tr>
-    <tr>
-      <td> DataMapper</td>
-      <td> Yes</td>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-    </tr>
-    <tr>
-      <td> CouchPotato</td>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-    <tr>
-      <td> MongoMapper</td>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-    <tr>
-      <td> Mongoid</td>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-    <tr>
-      <td> Sequel</td>
-      <td> <b>Yes</b></td>
-      <td> Yes</td>
-      <td> Yes</td>
-    </tr>
-    <tr>
-      <td>Redis</td>
-      <td><b>Yes</b></td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Ohm</td>
-      <td><b>Yes</b></td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Neo4j</td>
-      <td>Yes</td>
-      <td>Yes*</td>
-      <td>Yes*</td>
-    </tr>
-  </tbody>
-</table>
-
-\* Truncation and Deletion strategies for Neo4j will just delete all nodes and relationships from the database.
-
-<table>
-  <tbody>
-    <tr>
-      <th>Driver</th>
-      <th>Truncation</th>
-      <th>Transaction</th>
-      <th>Deletion</th>
-    </tr>
-    <tr>
-      <td> Mongo</td>
-      <td> Yes</td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-    <tr>
-      <td> Moped</td>
-      <td> Yes</td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-  </tbody>
-</table>
+Gem | ORM | Truncation | Transaction | Deletion
+--- | --- | ---------- | ----------- | --------
+[database_cleaner-active_record](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-active_record) | ActiveRecord | Yes | **Yes** | Yes
+[database_cleaner-data_mapper](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-data_mapper) | DataMapper | Yes | **Yes** | No
+[database_cleaner-couch_potato](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-couch_potato) | CouchPotato | **Yes** | No | No
+[database_cleaner-mongo](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongo) | Mongo | **Yes** | No | No
+[database_cleaner-mongo_mapper](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongo_mapper) | MongoMapper | **Yes** | No | No
+[database_cleaner-mongoid](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-mongoid) | Mongoid | **Yes** | No | No
+[database_cleaner-moped](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-moped) | Moped | **Yes** | No | No
+[database_cleaner-sequel](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-sequel) | Sequel | **Yes** | Yes | Yes
+[database_cleaner-redis](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-redis) | Redis | **Yes** | No | No
+[database_cleaner-ohm](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-ohm) | Ohm | **Yes** | No | No
+[database_cleaner-neo4j](https://github.com/DatabaseCleaner/database_cleaner/adapters/database_cleaner-neo4j) | Neo4j | Yes | **Yes** | Yes
 
 (Default strategy for each library is denoted in bold)
 
@@ -143,7 +80,7 @@ Because database_cleaner supports multiple ORMs, it doesn't make sense to includ
 ## How to use
 
 ```ruby
-require 'database_cleaner'
+require 'database_cleaner/active_record'
 
 DatabaseCleaner.strategy = :truncation
 
@@ -169,7 +106,7 @@ passed to [`keys`](http://redis.io/commands/keys)).
 Some strategies need to be started before tests are run (for example the `:transaction` strategy needs to know to open up a transaction). This can be accomplished by calling `DatabaseCleaner.start` at the beginning of the run, or by running the tests inside a block to `DatabaseCleaner.cleaning`. So you would have:
 
 ```ruby
-require 'database_cleaner'
+require 'database_cleaner/active_record'
 
 DatabaseCleaner.strategy = :transaction
 
@@ -191,7 +128,7 @@ At times you may want to do a single clean with one strategy.
 For example, you may want to start the process by truncating all the tables, but then use the faster transaction strategy the remaining time. To accomplish this you can say:
 
 ```ruby
-require 'database_cleaner'
+require 'database_cleaner/active_record'
 
 DatabaseCleaner.clean_with :truncation
 
@@ -345,14 +282,9 @@ If you're using Cucumber with Rails, just use the generator that ships with cucu
 Otherwise, to add DatabaseCleaner to your project by hand, create a file `features/support/database_cleaner.rb` that looks like this:
 
 ```ruby
-begin
-  require 'database_cleaner'
-  require 'database_cleaner/cucumber'
+require 'database_cleaner/active_record'
 
-  DatabaseCleaner.strategy = :truncation
-rescue NameError
-  raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
-end
+DatabaseCleaner.strategy = :truncation
 
 Around do |scenario, block|
   DatabaseCleaner.cleaning(&block)
@@ -370,11 +302,14 @@ Sometimes you need to use multiple ORMs in your application.
 You can use DatabaseCleaner to clean multiple ORMs, and multiple connections for those ORMs.
 
 ```ruby
-#How to specify particular orms
+require 'database_cleaner/active_record'
+require 'database_cleaner/mongo_mapper'
+
+# How to specify particular orms
 DatabaseCleaner[:active_record].strategy = :transaction
 DatabaseCleaner[:mongo_mapper].strategy = :truncation
 
-#How to specify particular connections
+# How to specify particular connections
 DatabaseCleaner[:active_record, { :connection => :two }]
 
 # You may also pass in the model directly:
@@ -496,7 +431,7 @@ When you are using [neo4j](https://github.com/neo4jrb/neo4j) gem it creates sche
 Add to your rails_helper or spec_helper after requiring database_cleaner:
 
 ```ruby
-require 'database_cleaner'
+require 'database_cleaner-neo4j'
 Dir["#{Rails.root}/app/models/**/*.rb"].each do |model|
   load model
 end
@@ -545,4 +480,4 @@ DatabaseCleaner.logger = Rails.logger
 
 ## COPYRIGHT
 
-Copyright (c) 2014 Ben Mabey. See LICENSE for details.
+See [LICENSE] for details.

--- a/adapters/database_cleaner-active_record/README.md
+++ b/adapters/database_cleaner-active_record/README.md
@@ -56,223 +56,6 @@ Some people report much faster speeds with `:deletion` while others say `:trunca
 
 If you are using ActiveRecord then take a look at the [additional options](#additional-activerecord-options-for-truncation) available for `:truncation`.
 
-## How to use
-
-```ruby
-require 'database_cleaner/active_record'
-
-DatabaseCleaner.strategy = :truncation
-
-# then, whenever you need to clean the DB
-DatabaseCleaner.clean
-```
-
-With the `:truncation` strategy you can also pass in options, for example:
-
-```ruby
-DatabaseCleaner.strategy = :truncation, only: %w[widgets dogs some_other_table]
-```
-
-```ruby
-DatabaseCleaner.strategy = :truncation, except: %w[widgets]
-```
-
-(I should point out the truncation strategy will never truncate your schema_migrations table.)
-
-Some strategies need to be started before tests are run (for example the `:transaction` strategy needs to know to open up a transaction). This can be accomplished by calling `DatabaseCleaner.start` at the beginning of the run, or by running the tests inside a block to `Database.cleaning`. So you would have:
-
-```ruby
-require 'database_cleaner/active_record'
-
-DatabaseCleaner.strategy = :transaction
-
-DatabaseCleaner.start # usually this is called in setup of a test
-
-dirty_the_db
-
-DatabaseCleaner.clean # cleanup of the test
-
-# OR
-
-DatabaseCleaner.cleaning do
-  dirty_the_db
-end
-```
-
-At times you may want to do a single clean with one strategy.
-
-For example, you may want to start the process by truncating all the tables, but then use the faster transaction strategy the remaining time. To accomplish this you can say:
-
-```ruby
-require 'database_cleaner/active_record'
-
-DatabaseCleaner.clean_with :truncation
-
-DatabaseCleaner.strategy = :transaction
-
-# then make the DatabaseCleaner.start and DatabaseCleaner.clean calls appropriately
-```
-
-### Additional ActiveRecord options for Truncation
-
-The following options are available for ActiveRecord's `:truncation` strategy _only_ for MySQL and Postgres.
-
-* `:pre_count` - When set to `true` this will check each table for existing rows before truncating it.  This can speed up test suites when many of the tables to be truncated are never populated. Defaults to `:false`. (Also, see the section on [What strategy is fastest?](#what-strategy-is-fastest))
-* `:reset_ids` - This only matters when `:pre_count` is used, and it will make sure that a tables auto-incrementing id is reset even if there are no rows in the table (e.g. records were created in the test but also removed before DatabaseCleaner gets to it). Defaults to `true`.
-
-The following option is available for ActiveRecord's `:truncation` and `:deletion` strategy for any DB.
-
-* `:cache_tables` - When set to `true` the list of tables to truncate or delete from will only be read from the DB once, otherwise it will be read before each cleanup run. Set this to `false` if (1) you create and drop tables in your tests, or (2) you change Postgres schemas (`ActiveRecord::Base.connection.schema_search_path`) in your tests (for example, in a multitenancy setup with each tenant in a different Postgres schema). Defaults to `true`.
-
-
-### RSpec Example
-
-```ruby
-RSpec.configure do |config|
-
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
-  end
-
-end
-```
-
-### RSpec with Capybara Example
-
-You'll typically discover a feature spec is incorrectly using transaction
-instead of truncation strategy when the data created in the spec is not
-visible in the app-under-test.
-
-A frequently occurring example of this is when, after creating a user in a
-spec, the spec mysteriously fails to login with the user. This happens because
-the user is created inside of an uncommitted transaction on one database
-connection, while the login attempt is made using a separate database
-connection. This separate database connection cannot access the
-uncommitted user data created over the first database connection due to
-transaction isolation.
-
-For feature specs using a Capybara driver for an external
-JavaScript-capable browser (in practice this is all drivers except
-`:rack_test`), the Rack app under test and the specs do not share a
-database connection.
-
-When a spec and app-under-test do not share a database connection,
-you'll likely need to use the truncation strategy instead of the
-transaction strategy.
-
-See the suggested config below to temporarily enable truncation strategy
-for affected feature specs only. This config continues to use transaction
-strategy for all other specs.
-
-It's also recommended to use `append_after` to ensure `DatabaseCleaner.clean`
-runs *after* the after-test cleanup `capybara/rspec` installs.
-
-```ruby
-require 'capybara/rspec'
-
-#...
-
-RSpec.configure do |config|
-
-  config.use_transactional_fixtures = false
-
-  config.before(:suite) do
-    if config.use_transactional_fixtures?
-      raise(<<-MSG)
-        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
-        (or set it to false) to prevent uncommitted transactions being used in
-        JavaScript-dependent specs.
-
-        During testing, the app-under-test that the browser driver connects to
-        uses a different database connection to the database connection used by
-        the spec. The app's database connection would not be able to access
-        uncommitted transaction data setup over the spec's database connection.
-      MSG
-    end
-    DatabaseCleaner.clean_with(:truncation)
-  end  
-
-  config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, type: :feature) do
-    # :rack_test driver's Rack app under test shares database connection
-    # with the specs, so continue to use transaction strategy for speed.
-    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
-
-    if !driver_shares_db_connection_with_specs
-      # Driver is probably for an external browser with an app
-      # under test that does *not* share a database connection with the
-      # specs, so use truncation strategy.
-      DatabaseCleaner.strategy = :truncation
-    end
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.append_after(:each) do
-    DatabaseCleaner.clean
-  end
-
-end
-```
-
-### Minitest Example
-
-```ruby
-DatabaseCleaner.strategy = :transaction
-
-class Minitest::Spec
-  before :each do
-    DatabaseCleaner.start
-  end
-
-  after :each do
-    DatabaseCleaner.clean
-  end
-end
-
-# with the minitest-around gem, this may be used instead:
-class Minitest::Spec
-  around do |tests|
-    DatabaseCleaner.cleaning(&tests)
-  end
-end
-```
-
-### Cucumber Example
-
-If you're using Cucumber with Rails, just use the generator that ships with cucumber-rails, and that will create all the code you need to integrate DatabaseCleaner into your Rails project.
-
-Otherwise, to add DatabaseCleaner to your project by hand, create a file `features/support/database_cleaner.rb` that looks like this:
-
-```ruby
-begin
-  require 'database_cleaner/active_record'
-  require 'database_cleaner/cucumber'
-
-  DatabaseCleaner.strategy = :truncation
-rescue NameError
-  raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
-end
-
-Around do |scenario, block|
-  DatabaseCleaner.cleaning(&block)
-end
-```
-
-This should cover the basics of tear down between scenarios and keeping your database clean.
-
 ### Configuration options
 
 <table>
@@ -290,20 +73,19 @@ This should cover the basics of tear down between scenarios and keeping your dat
   </tbody>
 </table>
 
+### Additional ActiveRecord options for Truncation
+
+The following options are available for ActiveRecord's `:truncation` strategy _only_ for MySQL and Postgres.
+
+* `:pre_count` - When set to `true` this will check each table for existing rows before truncating it.  This can speed up test suites when many of the tables to be truncated are never populated. Defaults to `:false`. (Also, see the section on [What strategy is fastest?](#what-strategy-is-fastest))
+* `:reset_ids` - This only matters when `:pre_count` is used, and it will make sure that a tables auto-incrementing id is reset even if there are no rows in the table (e.g. records were created in the test but also removed before DatabaseCleaner gets to it). Defaults to `true`.
+
+The following option is available for ActiveRecord's `:truncation` and `:deletion` strategy for any DB.
+
+* `:cache_tables` - When set to `true` the list of tables to truncate or delete from will only be read from the DB once, otherwise it will be read before each cleanup run. Set this to `false` if (1) you create and drop tables in your tests, or (2) you change Postgres schemas (`ActiveRecord::Base.connection.schema_search_path`) in your tests (for example, in a multitenancy setup with each tenant in a different Postgres schema). Defaults to `true`.
+
+
 ## Common Errors
-
-#### DatabaseCleaner is trying to use the wrong ORM
-
-DatabaseCleaner has an autodetect mechanism where if you do not explicitly define your ORM it will use the first ORM it can detect that is loaded.
-
-Since ActiveRecord is the most common ORM used that is the first one checked for.
-
-Sometimes other libraries (e.g. ActiveAdmin) will load other ORMs (e.g. ActiveRecord) even though you are using a different ORM.  This will result in DatabaseCleaner trying to use the wrong ORM (e.g. ActiveRecord) unless you explicitly define your ORM like so:
-
-```ruby
-# How to setup your ORM explicitly
-DatabaseCleaner[:mongoid].strategy = :truncation
-```
 
 ### STDERR is being flooded when using Postgres
 
@@ -323,16 +105,6 @@ test:
   # ...
   min_messages: WARNING  
 </pre>
-
-## Debugging
-
-In rare cases DatabaseCleaner will encounter errors that it will log.  By default it uses STDOUT set to the ERROR level but you can configure this to use whatever Logger you desire.
-
-Here's an example of using the `Rails.logger` in `env.rb`:
-
-```ruby
-DatabaseCleaner.logger = Rails.logger
-```
 
 ## COPYRIGHT
 

--- a/adapters/database_cleaner-active_record/README.md
+++ b/adapters/database_cleaner-active_record/README.md
@@ -1,14 +1,13 @@
-# Database Cleaner for ActiveRecord
+# Database Cleaner Adapter for ActiveRecord
 
 [![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-active_record.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-active_record)
 [![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-active_record/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-active_record)
 
-Database Cleaner is a set of strategies for cleaning your database in Ruby.
+Clean your ActiveRecord databases with Database Cleaner.
 
-The original use case was to ensure a clean state during tests.
-Each strategy is a small amount of code but is code that is usually needed in any ruby app that is testing with a database.
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
-## Gem Setup
+## Installation
 
 ```ruby
 # Gemfile
@@ -56,7 +55,7 @@ Some people report much faster speeds with `:deletion` while others say `:trunca
 
 If you are using ActiveRecord then take a look at the [additional options](#additional-activerecord-options-for-truncation) available for `:truncation`.
 
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>

--- a/adapters/database_cleaner-couch_potato/README.md
+++ b/adapters/database_cleaner-couch_potato/README.md
@@ -16,6 +16,27 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+Here is an overview of the supported strategies:
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>

--- a/adapters/database_cleaner-couch_potato/README.md
+++ b/adapters/database_cleaner-couch_potato/README.md
@@ -22,7 +22,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Couch Potato</td>
+      <td> <code>DatabaseCleaner[:couch_potato]</code></td>
+      <td> Multiple connections not yet supported</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-couch_potato/README.md
+++ b/adapters/database_cleaner-couch_potato/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::CouchPotato
+# Database Cleaner Adapter for CouchPotato
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/couch_potato`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-couch_potato.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-couch_potato)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-couch_potato/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-couch_potato)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your CouchPotato databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-couch_potato'
+# Gemfile
+group :test do
+  gem 'database_cleaner-couch_potato'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-couch_potato
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -39,16 +33,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-couch_potato.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-data_mapper/Gemfile.lock
+++ b/adapters/database_cleaner-data_mapper/Gemfile.lock
@@ -9,12 +9,13 @@ PATH
     database_cleaner-data_mapper (1.8.0)
       database_cleaner (~> 1.8.0)
       datamapper
+      dm-transactions
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
-    bcrypt (3.1.7)
+    bcrypt (3.1.12)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
     data_objects (0.10.14)
@@ -68,8 +69,8 @@ GEM
       data_objects (= 0.10.14)
     fastercsv (1.5.5)
     json (1.8.6)
-    json_pure (1.8.1)
-    multi_json (1.2.0)
+    json_pure (1.8.6)
+    multi_json (1.13.1)
     rake (10.4.2)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)

--- a/adapters/database_cleaner-data_mapper/README.md
+++ b/adapters/database_cleaner-data_mapper/README.md
@@ -22,7 +22,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Data Mapper</td>
+      <td> <code>DatabaseCleaner[:data_mapper]</code></td>
+      <td> Connection specified as <code>:symbol</code> keys, loaded via Datamapper repositories </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-data_mapper/README.md
+++ b/adapters/database_cleaner-data_mapper/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::DataMapper
+# Database Cleaner Adapter for DataMapper
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/data_mapper`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-data_mapper.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-data_mapper)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-data_mapper/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-data_mapper)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your DataMapper databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-data_mapper'
+# Gemfile
+group :test do
+  gem 'database_cleaner-data_mapper'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-data_mapper
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -39,16 +33,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-data_mapper.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-data_mapper/README.md
+++ b/adapters/database_cleaner-data_mapper/README.md
@@ -16,6 +16,27 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+Here is an overview of the supported strategies:
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> Yes</td>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>

--- a/adapters/database_cleaner-data_mapper/database_cleaner-data_mapper.gemspec
+++ b/adapters/database_cleaner-data_mapper/database_cleaner-data_mapper.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "database_cleaner", "~> 1.8.0"
   spec.add_dependency "datamapper"
+  spec.add_dependency "dm-transactions"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/adapters/database_cleaner-mongo/README.md
+++ b/adapters/database_cleaner-mongo/README.md
@@ -16,6 +16,42 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
+## Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Mongo</td>
+      <td> <code>DatabaseCleaner[:mongo]</code></td>
+      <td> </td>
+    </tr>
+  </tbody>
+</table>
+
 ## COPYRIGHT
 
 See [LICENSE] for details.

--- a/adapters/database_cleaner-mongo/README.md
+++ b/adapters/database_cleaner-mongo/README.md
@@ -1,39 +1,21 @@
-# DatabaseCleaner::Mongo
+# Database Cleaner Adapter for Mongo
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/mongo`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-mongo.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-mongo)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-mongo/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-mongo)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Mongo databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-mongo'
+# Gemfile
+group :test do
+  gem 'database_cleaner-mongo'
+end
 ```
 
-And then execute:
+## COPYRIGHT
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-mongo
-
-## Usage
-
-TODO: Write usage instructions here
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-mongo.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-mongo_mapper/README.md
+++ b/adapters/database_cleaner-mongo_mapper/README.md
@@ -22,7 +22,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Mongo Mapper</td>
+      <td> <code>DatabaseCleaner[:mongo_mapper]</code></td>
+      <td> Multiple connections not yet supported</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-mongo_mapper/README.md
+++ b/adapters/database_cleaner-mongo_mapper/README.md
@@ -16,6 +16,25 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>

--- a/adapters/database_cleaner-mongo_mapper/README.md
+++ b/adapters/database_cleaner-mongo_mapper/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::MongoMapper
+# Database Cleaner Adapter for MongoMapper
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/mongo_mapper`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-mongo_mapper.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-mongo_mapper)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-mongo_mapper/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-mongo_mapper)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your MongoMapper databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-mongo_mapper'
+# Gemfile
+group :test do
+  gem 'database_cleaner-mongo_mapper'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-mongo_mapper
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -39,16 +33,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-mongo_mapper.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-mongoid/README.md
+++ b/adapters/database_cleaner-mongoid/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::Mongoid
+# Database Cleaner Adapter for Mongoid
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/mongoid`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-mongoid.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-mongoid)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-mongoid/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-mongoid)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Mongoid databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-mongoid'
+# Gemfile
+group :test do
+  gem 'database_cleaner-mongoid'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-mongoid
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -39,16 +33,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-mongoid.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-mongoid/README.md
+++ b/adapters/database_cleaner-mongoid/README.md
@@ -22,7 +22,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Mongoid</td>
+      <td> <code>DatabaseCleaner[:mongoid]</code></td>
+      <td> Multiple databases supported for Mongoid 3. Specify <code>DatabaseCleaner[:mongoid, {:connection =&gt; :db_name}]</code> </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-mongoid/README.md
+++ b/adapters/database_cleaner-mongoid/README.md
@@ -16,6 +16,25 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>

--- a/adapters/database_cleaner-moped/README.md
+++ b/adapters/database_cleaner-moped/README.md
@@ -22,7 +22,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Moped</td>
+      <td> <code>DatabaseCleaner[:moped]</code></td>
+      <td> It is necessary to configure database name with <code>DatabaseCleaner[:moped].db = db_name</code> otherwise name `default` will be used.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-moped/README.md
+++ b/adapters/database_cleaner-moped/README.md
@@ -16,6 +16,25 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>

--- a/adapters/database_cleaner-moped/README.md
+++ b/adapters/database_cleaner-moped/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::Moped
+# Database Cleaner Adapter for Moped
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/moped`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-moped.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-moped)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-moped/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-moped)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Moped databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-moped'
+# Gemfile
+group :test do
+  gem 'database_cleaner-moped'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-moped
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -39,16 +33,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-moped.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-neo4j/README.md
+++ b/adapters/database_cleaner-neo4j/README.md
@@ -1,30 +1,22 @@
-# DatabaseCleaner::Neo4j
+# Database Cleaner Adapter for Neo4j
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/neo4j`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-neo4j.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-neo4j)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-neo4j/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-neo4j)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Neo4j databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-neo4j'
+# Gemfile
+group :test do
+  gem 'database_cleaner-neo4j'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-neo4j
-
-## Usage
-
-Truncation and Deletion strategies for Neo4j will just delete all nodes and relationships from the database.
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -41,31 +33,24 @@ Truncation and Deletion strategies for Neo4j will just delete all nodes and rela
   </tbody>
 </table>
 
+Note that Truncation and Deletion strategies for Neo4j will just delete all nodes and relationships from the database.
+
 ## Common Errors
 
 ### Model fails to load with Neo4j using transactions
 
 When you are using [neo4j](https://github.com/neo4jrb/neo4j) gem it creates schema and reads indexes upon loading models. These operations can't be done during a transaction. You have to preload your models before DatabaseCleaner starts a transaction.
 
-Add to your rails_helper or spec_helper after requiring database_cleaner:
+Add to your rails_helper or spec_helper after requiring database_cleaner-neo4j:
 
 ```ruby
-require 'database_cleaner-neo4j'
+require 'database_cleaner/neo4j'
+
 Dir["#{Rails.root}/app/models/**/*.rb"].each do |model|
   load model
 end
 ```
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-neo4j.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-neo4j/README.md
+++ b/adapters/database_cleaner-neo4j/README.md
@@ -22,7 +22,39 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Truncation and Deletion strategies for Neo4j will just delete all nodes and relationships from the database.
+
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td>Neo4j</td>
+      <td><code>DatabaseCleaner[:neo4j]</code></td>
+      <td>Database type and path(URI) <code>DatabaseCleaner[:neo4j, connection: {type: :server_db, path: 'http://localhost:7475'}].</code></td>
+    </tr>
+  </tbody>
+</table>
+
+## Common Errors
+
+### Model fails to load with Neo4j using transactions
+
+When you are using [neo4j](https://github.com/neo4jrb/neo4j) gem it creates schema and reads indexes upon loading models. These operations can't be done during a transaction. You have to preload your models before DatabaseCleaner starts a transaction.
+
+Add to your rails_helper or spec_helper after requiring database_cleaner:
+
+```ruby
+require 'database_cleaner-neo4j'
+Dir["#{Rails.root}/app/models/**/*.rb"].each do |model|
+  load model
+end
+```
 
 ## Development
 

--- a/adapters/database_cleaner-neo4j/README.md
+++ b/adapters/database_cleaner-neo4j/README.md
@@ -16,6 +16,25 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> Yes</td>
+      <td> <b>Yes</b></td>
+      <td> Yes</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>

--- a/adapters/database_cleaner-ohm/README.md
+++ b/adapters/database_cleaner-ohm/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::Ohm
+# Database Cleaner Adapter for Ohm
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/ohm`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-ohm.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-ohm)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-ohm/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-ohm)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Ohm databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-ohm'
+# Gemfile
+group :test do
+  gem 'database_cleaner-ohm'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-ohm
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 `:only` and `:except` take a list of strings to be passed to [`keys`](http://redis.io/commands/keys)).
 
@@ -41,16 +35,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-ohm.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-ohm/README.md
+++ b/adapters/database_cleaner-ohm/README.md
@@ -22,7 +22,24 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+`:only` and `:except` take a list of strings to be passed to [`keys`](http://redis.io/commands/keys)).
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td>Ohm</td>
+      <td><code>DatabaseCleaner[:ohm]</code></td>
+      <td>Connection specified as Redis URI</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-ohm/README.md
+++ b/adapters/database_cleaner-ohm/README.md
@@ -16,6 +16,25 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 `:only` and `:except` take a list of strings to be passed to [`keys`](http://redis.io/commands/keys)).

--- a/adapters/database_cleaner-redis/README.md
+++ b/adapters/database_cleaner-redis/README.md
@@ -16,6 +16,25 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> <b>Yes</b></td>
+      <td> No</td>
+      <td> No</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 `:only` and `:except` take a list of strings to be passed to [`keys`](http://redis.io/commands/keys)).

--- a/adapters/database_cleaner-redis/README.md
+++ b/adapters/database_cleaner-redis/README.md
@@ -22,7 +22,24 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+`:only` and `:except` take a list of strings to be passed to [`keys`](http://redis.io/commands/keys)).
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td>Redis</td>
+      <td><code>DatabaseCleaner[:redis]</code></td>
+      <td>Connection specified as Redis URI</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Development
 

--- a/adapters/database_cleaner-redis/README.md
+++ b/adapters/database_cleaner-redis/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::Redis
+# Database Cleaner Adapter for Redis
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/redis`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-redis.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-redis)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-redis/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-redis)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Redis databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-redis'
+# Gemfile
+group :test do
+  gem 'database_cleaner-redis'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-redis
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 `:only` and `:except` take a list of strings to be passed to [`keys`](http://redis.io/commands/keys)).
 
@@ -41,16 +35,6 @@ Or install it yourself as:
   </tbody>
 </table>
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-redis.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-sequel/README.md
+++ b/adapters/database_cleaner-sequel/README.md
@@ -22,7 +22,28 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Configuration options
+
+<table>
+  <tbody>
+    <tr>
+      <th>ORM</th>
+      <th>How to access</th>
+      <th>Notes</th>
+    </tr>
+    <tr>
+      <td> Sequel</td>
+      <td> <code>DatabaseCleaner[:sequel]</code></td>
+      <td> Multiple databases supported; specify <code>DatabaseCleaner[:sequel, {:connection =&gt; Sequel.connect(uri)}]</code></td>
+    </tr>
+  </tbody>
+</table>
+
+## Common Errors
+
+### Nothing happens in JRuby with Sequel using transactions
+
+Due to an inconsistency in JRuby's implementation of Fibers, Sequel gives a different connection to `DatabaseCleaner.start` than is used for tests run between `.start` and `.clean`. This can be worked around by running your tests in a block like `DatabaseCleaner.cleaning { run_my_tests }` instead, which does not use Fibers.
 
 ## Development
 

--- a/adapters/database_cleaner-sequel/README.md
+++ b/adapters/database_cleaner-sequel/README.md
@@ -1,28 +1,22 @@
-# DatabaseCleaner::Sequel
+# Database Cleaner Adapter for Sequel
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/database_cleaner/sequel`. To experiment with that code, run `bin/console` for an interactive prompt.
+[![Build Status](https://travis-ci.org/DatabaseCleaner/database_cleaner-sequel.svg?branch=master)](https://travis-ci.org/DatabaseCleaner/database_cleaner-sequel)
+[![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-sequel/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner-sequel)
 
-TODO: Delete this and the text above, and describe your gem
+Clean your Sequel databases with Database Cleaner.
+
+See https://github.com/DatabaseCleaner/database_cleaner for more information.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
 ```ruby
-gem 'database_cleaner-sequel'
+# Gemfile
+group :test do
+  gem 'database_cleaner-sequel'
+end
 ```
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install database_cleaner-sequel
-
-## Usage
-
-### Configuration options
+## Configuration options
 
 <table>
   <tbody>
@@ -45,16 +39,6 @@ Or install it yourself as:
 
 Due to an inconsistency in JRuby's implementation of Fibers, Sequel gives a different connection to `DatabaseCleaner.start` than is used for tests run between `.start` and `.clean`. This can be worked around by running your tests in a block like `DatabaseCleaner.cleaning { run_my_tests }` instead, which does not use Fibers.
 
-## Development
+## COPYRIGHT
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/database_cleaner-sequel.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+See [LICENSE] for details.

--- a/adapters/database_cleaner-sequel/README.md
+++ b/adapters/database_cleaner-sequel/README.md
@@ -16,6 +16,27 @@ group :test do
 end
 ```
 
+## Supported Strategies
+
+Here is an overview of the supported strategies:
+
+<table>
+  <tbody>
+    <tr>
+      <th>Truncation</th>
+      <th>Transaction</th>
+      <th>Deletion</th>
+    </tr>
+    <tr>
+      <td> Yes</td>
+      <td> <b>Yes</b></td>
+      <td> Yes</td>
+    </tr>
+  </tbody>
+</table>
+
+(Default strategy is denoted in bold)
+
 ## Configuration options
 
 <table>


### PR DESCRIPTION
I started this PR to try to get documentation in shape for the upcoming 1.8.0 release. After trying out a few different ways of organizing the information, it seems to me like the easiest way to go about this is for the base README to cover general usage of the library, while the adapter gems' READMEs cover configuration and gotchas specific to the adapter.

This PR is a Work In Progress, because I still need to go through and work all the READMEs for the various adapters. However, I think the base README and the ActiveRecord adapter README look pretty good. What do you think? If you like this direction, I'll do the work to finish up the adapter READMEs.