### PR TITLE
Exclude ar_internal_metadata from truncation on Rails 5

### DIFF
--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
@@ -260,7 +260,10 @@ module DatabaseCleaner::ActiveRecord
 
     # overwritten
     def migration_storage_names
-      [::DatabaseCleaner::ActiveRecord::Base.migration_table_name]
+      [].tap do |arr|
+        arr << ::DatabaseCleaner::ActiveRecord::Base.migration_table_name
+        arr << ::ActiveRecord::Base.internal_metadata_table_name if ::ActiveRecord::VERSION::MAJOR >= 5
+      end
     end
 
     def cache_tables?

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -47,15 +47,6 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             expect(count).to eq 2
           end
 
-          it "should not truncate ar_internal_metadata on Rails 5" do
-            allow(::ActiveRecord::Base).to receive(:internal_metadata_table_name).and_return('ar_internal_metadata')
-            stub_const("::ActiveRecord::VERSION::MAJOR", 5)
-            expect(connection)
-              .not_to receive(:truncate_table)
-              .with(::ActiveRecord::Base.internal_metadata_table_name)
-            subject.clean
-          end
-
           it "should only truncate the tables specified in the :only option when provided" do
             expect { described_class.new(only: ['agents']).clean }
               .to change { [User.count, Agent.count] }

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
           end
 
           it "should not truncate ar_internal_metadata on Rails 5" do
+            allow(::ActiveRecord::Base).to receive(:internal_metadata_table_name).and_return('ar_internal_metadata')
             stub_const("::ActiveRecord::VERSION::MAJOR", 5)
             expect(connection)
               .not_to receive(:truncate_table)

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             expect(count).to eq 2
           end
 
+          it "should not truncate ar_internal_metadata on Rails 5" do
+            stub_const("::ActiveRecord::VERSION::MAJOR", 5)
+            expect(connection)
+              .not_to receive(:truncate_table)
+              .with(::DatabaseCleaner::ActiveRecord::Base.internal_metadata_table_name)
+            subject.clean
+          end
+
           it "should only truncate the tables specified in the :only option when provided" do
             expect { described_class.new(only: ['agents']).clean }
               .to change { [User.count, Agent.count] }

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             stub_const("::ActiveRecord::VERSION::MAJOR", 5)
             expect(connection)
               .not_to receive(:truncate_table)
-              .with(::DatabaseCleaner::ActiveRecord::Base.internal_metadata_table_name)
+              .with(::ActiveRecord::Base.internal_metadata_table_name)
             subject.clean
           end
 


### PR DESCRIPTION
Quick fix for the ActiveRecord adapter. This was fixed for the Postgres adapter in Issue  https://github.com/DatabaseCleaner/database_cleaner/issues/445, PR  https://github.com/DatabaseCleaner/database_cleaner/pull/487.

I wrote a spec but had problems building the mysql 2.9.1 gem, so was unable to run the spec (sorry!) but I did load the gem in a project and verified the fix manually.