### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1
   - 2.2
 before_install:
+  - gem install bundler -v 1.17.3
   - | # cached install of Neo4j locally:
     if [ ! -d neo4j-community-2.3.3/bin ];
     then

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ PATH
     database_cleaner-data_mapper (1.8.0)
       database_cleaner (~> 1.8.0)
       datamapper
+      dm-transactions
     database_cleaner-mongo (1.8.0)
       database_cleaner (~> 1.8.0)
       mongo
@@ -321,4 +322,4 @@ DEPENDENCIES
   tzinfo
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
Looks like the Gemfile.lock was missing a dependency? Not sure how this could have possibly happened, but whatever. Also locked down the bundler version in Travis config to keep things reproducible. Fixes #593