### PR TITLE
Update `truncate_tables` to allow argument list of tables

### DIFF
--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
@@ -50,7 +50,7 @@ module DatabaseCleaner
         execute("TRUNCATE TABLE #{quote_table_name(table_name)};")
       end
 
-      def truncate_tables(tables)
+      def truncate_tables(*tables)
         tables.each { |t| truncate_table(t) }
       end
 

--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
@@ -160,7 +160,7 @@ module DatabaseCleaner
 
       def pre_count_truncate_tables(tables, options = {:reset_ids => true})
         filter = options[:reset_ids] ? method(:has_been_used?) : method(:has_rows?)
-        truncate_tables(tables.select(&filter))
+        truncate_tables(*tables.select(&filter))
       end
 
       def database_cleaner_table_cache

--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
@@ -56,7 +56,7 @@ module DatabaseCleaner
 
       def pre_count_truncate_tables(tables, options = {:reset_ids => true})
         filter = options[:reset_ids] ? method(:has_been_used?) : method(:has_rows?)
-        truncate_tables(tables.select(&filter))
+        truncate_tables(*tables.select(&filter))
       end
 
       private
@@ -239,7 +239,7 @@ module DatabaseCleaner::ActiveRecord
         if pre_count? && connection.respond_to?(:pre_count_truncate_tables)
           connection.pre_count_truncate_tables(tables_to_truncate(connection), {:reset_ids => reset_ids?})
         else
-          connection.truncate_tables(tables_to_truncate(connection))
+          connection.truncate_tables(*tables_to_truncate(connection))
         end
       end
     end

--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/truncation.rb
@@ -38,7 +38,8 @@ module DatabaseCleaner
         raise NotImplementedError
       end
 
-      def truncate_tables(tables)
+      def truncate_tables(*tables)
+        tables.flatten!
         tables.each do |table_name|
           self.truncate_table(table_name)
         end
@@ -51,6 +52,7 @@ module DatabaseCleaner
       end
 
       def truncate_tables(*tables)
+        tables.flatten!
         tables.each { |t| truncate_table(t) }
       end
 
@@ -104,7 +106,8 @@ module DatabaseCleaner
       end
       alias truncate_table delete_table
 
-      def truncate_tables(tables)
+      def truncate_tables(*tables)
+        tables.flatten!
         tables.each { |t| truncate_table(t) }
       end
 
@@ -149,7 +152,8 @@ module DatabaseCleaner
         truncate_tables([table_name])
       end
 
-      def truncate_tables(table_names)
+      def truncate_tables(*table_names)
+        table_names.flatten!
         return if table_names.nil? || table_names.empty?
         execute("TRUNCATE TABLE #{table_names.map{|name| quote_table_name(name)}.join(', ')} #{restart_identity} #{cascade};")
       end

--- a/adapters/database_cleaner-active_record/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/adapters/database_cleaner-active_record/spec/database_cleaner/active_record/truncation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             allow(connection).to receive(:database_cleaner_table_cache).and_return(%w[widgets dogs])
             allow(connection).to receive(:database_cleaner_view_cache).and_return(["widgets"])
 
-            expect(connection).to receive(:truncate_tables).with(['dogs'])
+            expect(connection).to receive(:truncate_tables).with('dogs')
 
             subject.clean
           end
@@ -90,7 +90,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
 
             User.create!
 
-            expect(connection).to receive(:truncate_tables).with(['users'])
+            expect(connection).to receive(:truncate_tables).with('users')
             subject.clean
           end
         end
@@ -112,6 +112,27 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
 
             allow(connection).to receive(:truncate_tables)
             described_class.new(cache_tables: false).clean
+          end
+        end
+
+        context 'truncate tables with different arg inputs' do
+          before do
+            2.times { User.create! }
+            2.times { Agent.create! }
+          end
+
+          it "should truncate given a list of tables" do
+            expect { connection.truncate_tables(['users', 'agents']) }
+              .to change { [User.count, Agent.count] }
+              .from([2,2])
+              .to([0,0])
+          end
+
+          it "should truncate given tables as args" do
+            expect { connection.truncate_tables('users', 'agents') }
+              .to change { [User.count, Agent.count] }
+              .from([2,2])
+              .to([0,0])
           end
         end
       end

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -114,6 +114,22 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             described_class.new(cache_tables: false).clean
           end
         end
+
+        context 'truncate tables with different arg inputs' do
+          it "should truncate given a list of tables" do
+            expect { connection.truncate_tables(['users', 'agents']) }
+              .to change { [User.count, Agent.count] }
+              .from([2,2])
+              .to([0,0])
+          end
+
+          it "should truncate given tables as args" do
+            expect { connection.truncate_tables('users', 'agents') }
+              .to change { [User.count, Agent.count] }
+              .from([2,2])
+              .to([0,0])
+          end
+        end
       end
     end
   end

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             allow(connection).to receive(:database_cleaner_table_cache).and_return(%w[widgets dogs])
             allow(connection).to receive(:database_cleaner_view_cache).and_return(["widgets"])
 
-            expect(connection).to receive(:truncate_tables).with(['dogs'])
+            expect(connection).to receive(:truncate_tables).with('dogs')
 
             subject.clean
           end
@@ -90,7 +90,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
 
             User.create!
 
-            expect(connection).to receive(:truncate_tables).with(['users'])
+            expect(connection).to receive(:truncate_tables).with('users')
             subject.clean
           end
         end

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -116,6 +116,11 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
         end
 
         context 'truncate tables with different arg inputs' do
+          before do
+            2.times { User.create! }
+            2.times { Agent.create! }
+          end
+
           it "should truncate given a list of tables" do
             expect { connection.truncate_tables(['users', 'agents']) }
               .to change { [User.count, Agent.count] }


### PR DESCRIPTION
This PR is allows `truncate_tables` in the ActiveRecord adapter to take in a list of table names in two different ways: 1) as a regular array of tables: `truncate_tables(['users','agents'])` or 2) as a list of arguments: `truncate_tables('users','agents')`. This is because when using DatabaseCleaner in conjunction with a connection adapter to imitate the `truncate_tables` method as it's implemented in the [rails 6 version of active record](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L188), cleaning with truncation is broken (as shown in an example error below).

```
An error occurred in a `before(:suite)` hook.
Failure/Error: DatabaseCleaner.clean_with(:truncation)

ActiveRecord::StatementInvalid:
  RandomAdapter::MysqlError: random_adapter_query_recv: 1103 Incorrect table name '["table1", "table2", "table3'
.
.
.
# /usr/local/bundle/gems/database_cleaner-1.7.0/lib/database_cleaner/active_record/truncation.rb:239:in `block in clean'
# /usr/local/bundle/gems/database_cleaner-1.7.0/lib/database_cleaner/active_record/truncation.rb:235:in `clean'
# /usr/local/bundle/gems/database_cleaner-1.7.0/lib/database_cleaner/base.rb:48:in `clean_with'
# /usr/local/bundle/gems/database_cleaner-1.7.0/lib/database_cleaner/configuration.rb:91:in `block in clean_with'
# /usr/local/bundle/gems/database_cleaner-1.7.0/lib/database_cleaner/configuration.rb:91:in `each'
# /usr/local/bundle/gems/database_cleaner-1.7.0/lib/database_cleaner/configuration.rb:91:in `clean_with'
# ./spec/rails_helper.rb:47:in `block (2 levels) in <top (required)>'
```

As you can see here, the `truncate_tables` method is trying to the array of tables as one table name. 

Let me know your thoughts on this! Thanks!