### PR TITLE
Introduce DatabaseCleaner.cleaners as a replacement for DatabaseCleaner.connections

### DIFF
--- a/lib/database_cleaner.rb
+++ b/lib/database_cleaner.rb
@@ -11,6 +11,8 @@ module DatabaseCleaner
       :app_root,
       :logger=,
       :logger,
+      :cleaners,
+      :cleaners=,
       :strategy=,
       :orm=,
       :start,

--- a/lib/database_cleaner/configuration.rb
+++ b/lib/database_cleaner/configuration.rb
@@ -16,7 +16,7 @@ module DatabaseCleaner
       @cleaners.fetch([orm, opts]) { add_cleaner(orm, opts) }
     end 
 
-    attr_accessor :app_root, :logger
+    attr_accessor :app_root, :logger, :cleaners
 
     def app_root
       @app_root ||= Dir.pwd
@@ -70,6 +70,9 @@ module DatabaseCleaner
     end
 
     def connections
+      if called_externally?(caller)
+        $stderr.puts "Calling `DatabaseCleaner.connections` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.cleaners`, instead."
+      end
       add_cleaner(:autodetect) if @cleaners.none?
       @cleaners.values
     end
@@ -79,6 +82,12 @@ module DatabaseCleaner
         cleaners[key] = value unless cleaners.values.include?(value)
         cleaners
       end
+    end
+
+    private
+
+    def called_externally?(caller)
+      __FILE__ != caller.first.split(":").first
     end
   end
 end


### PR DESCRIPTION
Back in the Ruby 1.8 days, hashes didn't guarantee insertion order, so an array was used internally to store the collection of cleaners. This has since been refactored to use a hash, which effectively matches the configuration API, e.g.: `DatabaseCleaner[:mongoid]`, but the old array accessor method remains in the public API. Therefore, I think we should deprecate the old array accessor for removal in v2.0, and replace it with a new getter `.cleaners` which exposes the internal hash configuration in a way that matches the configuration API.