### PR TITLE
Tighten up Public API

### DIFF
--- a/lib/database_cleaner.rb
+++ b/lib/database_cleaner.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.include?(File.expand_path(File.dirname(__FILE__)))
 require 'database_cleaner/configuration'
+require 'database_cleaner/deprecation'
 require 'forwardable'
 
 module DatabaseCleaner
@@ -32,6 +33,7 @@ module DatabaseCleaner
     attr_accessor :allow_remote_database_url, :allow_production, :url_whitelist
 
     def can_detect_orm?
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner.can_detect_orm?` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
       DatabaseCleaner::Base.autodetect_orm
     end
 

--- a/lib/database_cleaner.rb
+++ b/lib/database_cleaner.rb
@@ -20,12 +20,9 @@ module DatabaseCleaner
       :clean_with,
       :cleaning,
 
-      # TODO deprecate
+      # TODO remove in 2.0
       :clean!,
       :clean_with!,
-
-      # TODO deprecate and then privatize the following methods:
-
       :init_cleaners,
       :add_cleaner,
       :connections,

--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -23,34 +23,8 @@ module DatabaseCleaner
       @db = self.strategy_db = desired_db
     end
 
-    def strategy_db=(desired_db)
-      set_strategy_db(strategy, desired_db)
-    end
-
     def db
       @db ||= :default
-    end
-
-    def create_strategy(*args)
-      strategy, *strategy_args = args
-      orm_strategy(strategy).new(*strategy_args)
-    end
-
-    def clean_with(*args)
-      strategy = create_strategy(*args)
-      set_strategy_db strategy, db
-      strategy.clean
-      strategy
-    end
-
-    alias clean_with! clean_with
-
-    def set_strategy_db(strategy, desired_db)
-      if strategy.respond_to? :db=
-        strategy.db = desired_db
-      elsif desired_db != :default
-        raise ArgumentError, "You must provide a strategy object that supports non default databases when you specify a database"
-      end
     end
 
     def strategy=(args)
@@ -77,14 +51,6 @@ module DatabaseCleaner
       @orm = @orm_autodetector.orm if @orm == :autodetect
     end
 
-    def auto_detected?
-      @orm_autodetector.autodetected?
-    end
-
-    def autodetect_orm
-      @orm_autodetector.orm
-    end
-
     def start
       strategy.start
     end
@@ -93,10 +59,65 @@ module DatabaseCleaner
       strategy.clean
     end
 
-    alias clean! clean
-
     def cleaning(&block)
       strategy.cleaning(&block)
+    end
+
+    def clean_with(*args)
+      strategy = create_strategy(*args)
+      set_strategy_db strategy, db
+      strategy.clean
+      strategy
+    end
+
+    # TODO remove the following methods in 2.0
+
+    def auto_detected?
+      $stderr.puts "Calling `DatabaseCleaner[...].auto_detected?` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+      @orm_autodetector.autodetected?
+    end
+
+    def autodetect_orm
+      $stderr.puts "Calling `DatabaseCleaner[...].autodetect_orm` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+      @orm_autodetector.orm
+    end
+
+    def clean!
+      $stderr.puts "Calling `DatabaseCleaner[...].clean!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].clean instead."
+      clean
+    end
+
+    def clean_with!
+      $stderr.puts "Calling `DatabaseCleaner[...].clean_with!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].clean_with instead."
+      clean_with
+    end
+
+    # TODO privatize the following methods in 2.0
+
+    def strategy_db=(desired_db)
+      if called_externally?(caller)
+        $stderr.puts "Calling `DatabaseCleaner[...].strategy_db=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].db=` instead."
+      end
+      set_strategy_db(strategy, desired_db)
+    end
+
+    def set_strategy_db(strategy, desired_db)
+      if called_externally?(caller)
+        $stderr.puts "Calling `DatabaseCleaner[...].set_strategy_db=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].db=` instead."
+      end
+      if strategy.respond_to? :db=
+        strategy.db = desired_db
+      elsif desired_db != :default
+        raise ArgumentError, "You must provide a strategy object that supports non default databases when you specify a database"
+      end
+    end
+
+    def create_strategy(*args)
+      if called_externally?(caller)
+        $stderr.puts "Calling `DatabaseCleaner[...].create_strategy` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].strategy=` instead."
+      end
+      strategy, *strategy_args = args
+      orm_strategy(strategy).new(*strategy_args)
     end
 
     private
@@ -131,6 +152,10 @@ module DatabaseCleaner
       when :mongo_mapper, :mongoid, :couch_potato, :moped, :ohm, :redis
         :truncation
       end
+    end
+
+    def called_externally?(caller)
+      __FILE__ != caller.first.split(":").first
     end
   end
 end

--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -3,6 +3,7 @@ require 'database_cleaner/null_strategy'
 require 'database_cleaner/safeguard'
 require 'database_cleaner/orm_autodetector'
 require 'active_support/core_ext/string/inflections'
+require 'forwardable'
 
 module DatabaseCleaner
   class Base
@@ -52,17 +53,8 @@ module DatabaseCleaner
       @orm = @orm_autodetector.orm if @orm == :autodetect
     end
 
-    def start
-      strategy.start
-    end
-
-    def clean
-      strategy.clean
-    end
-
-    def cleaning(&block)
-      strategy.cleaning(&block)
-    end
+    extend Forwardable
+    delegate [:start, :clean, :cleaning] => :strategy
 
     def clean_with(*args)
       strategy = create_strategy(*args)

--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -1,3 +1,4 @@
+require 'database_cleaner/deprecation'
 require 'database_cleaner/null_strategy'
 require 'database_cleaner/safeguard'
 require 'database_cleaner/orm_autodetector'
@@ -73,22 +74,22 @@ module DatabaseCleaner
     # TODO remove the following methods in 2.0
 
     def auto_detected?
-      $stderr.puts "Calling `DatabaseCleaner[...].auto_detected?` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].auto_detected?` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
       @orm_autodetector.autodetected?
     end
 
     def autodetect_orm
-      $stderr.puts "Calling `DatabaseCleaner[...].autodetect_orm` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].autodetect_orm` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
       @orm_autodetector.orm
     end
 
     def clean!
-      $stderr.puts "Calling `DatabaseCleaner[...].clean!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].clean instead."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].clean!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].clean instead."
       clean
     end
 
     def clean_with!
-      $stderr.puts "Calling `DatabaseCleaner[...].clean_with!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].clean_with instead."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].clean_with!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].clean_with instead."
       clean_with
     end
 
@@ -96,14 +97,14 @@ module DatabaseCleaner
 
     def strategy_db=(desired_db)
       if called_externally?(caller)
-        $stderr.puts "Calling `DatabaseCleaner[...].strategy_db=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].db=` instead."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].strategy_db=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].db=` instead."
       end
       set_strategy_db(strategy, desired_db)
     end
 
     def set_strategy_db(strategy, desired_db)
       if called_externally?(caller)
-        $stderr.puts "Calling `DatabaseCleaner[...].set_strategy_db=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].db=` instead."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].set_strategy_db=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].db=` instead."
       end
       if strategy.respond_to? :db=
         strategy.db = desired_db
@@ -114,7 +115,7 @@ module DatabaseCleaner
 
     def create_strategy(*args)
       if called_externally?(caller)
-        $stderr.puts "Calling `DatabaseCleaner[...].create_strategy` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].strategy=` instead."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner[...].create_strategy` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner[...].strategy=` instead."
       end
       strategy, *strategy_args = args
       orm_strategy(strategy).new(*strategy_args)
@@ -130,7 +131,7 @@ module DatabaseCleaner
     def orm_strategy(strategy)
       orm_module.const_get(strategy.to_s.capitalize)
     rescue NameError
-      $stderr.puts <<-TEXT
+      DatabaseCleaner.deprecate <<-TEXT
         Requiring the `database_cleaner` gem directly is deprecated, and will raise an error in database_cleaner 2.0. Instead, please require the specific gem (or gems) for your ORM.
         For example, replace `gem "database_cleaner"` with `gem "database_cleaner-#{orm}"` in your Gemfile.
       TEXT

--- a/lib/database_cleaner/configuration.rb
+++ b/lib/database_cleaner/configuration.rb
@@ -49,9 +49,6 @@ module DatabaseCleaner
       :[],
       :strategy=,
       :orm=,
-
-      :add_cleaner,
-      :remove_duplicates,
     ] => :cleaners
 
     attr_accessor :app_root, :logger, :cleaners
@@ -82,12 +79,17 @@ module DatabaseCleaner
       connections.each { |connection| connection.clean_with(*args) }
     end
 
-    # TODO deprecate and remove the following aliases:
+    # TODO remove the following methods in 2.0
 
-    alias clean! clean
-    alias clean_with! clean_with
+    def clean!
+      $stderr.puts "Calling `DatabaseCleaner.clean!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.clean`, instead."
+      clean
+    end
 
-    # TODO deprecate and then privatize the following methods:
+    def clean_with!(*args)
+      $stderr.puts "Calling `DatabaseCleaner.clean_with!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.clean_with`, instead."
+      clean_with(*args)
+    end
 
     def init_cleaners
       $stderr.puts "Calling `DatabaseCleaner.init_cleaners` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
@@ -99,6 +101,22 @@ module DatabaseCleaner
       end
       add_cleaner(:autodetect) if @cleaners.none?
       @cleaners.values
+    end
+
+    # TODO privatize the following methods in 2.0
+
+    def add_cleaner(orm, opts = {})
+      if called_externally?(caller)
+        $stderr.puts "Calling `DatabaseCleaner.add_cleaner` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.[]`, instead."
+      end
+      @cleaners.add_cleaner(orm, opts = {})
+    end
+
+    def remove_duplicates
+      if called_externally?(caller)
+        $stderr.puts "Calling `DatabaseCleaner.remove_duplicates` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+      end
+      @cleaners.remove_duplicates
     end
 
     private

--- a/lib/database_cleaner/configuration.rb
+++ b/lib/database_cleaner/configuration.rb
@@ -1,4 +1,5 @@
 require 'database_cleaner/base'
+require 'database_cleaner/deprecation'
 require 'forwardable'
 
 module DatabaseCleaner
@@ -82,22 +83,22 @@ module DatabaseCleaner
     # TODO remove the following methods in 2.0
 
     def clean!
-      $stderr.puts "Calling `DatabaseCleaner.clean!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.clean`, instead."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner.clean!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.clean`, instead."
       clean
     end
 
     def clean_with!(*args)
-      $stderr.puts "Calling `DatabaseCleaner.clean_with!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.clean_with`, instead."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner.clean_with!` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.clean_with`, instead."
       clean_with(*args)
     end
 
     def init_cleaners
-      $stderr.puts "Calling `DatabaseCleaner.init_cleaners` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+      DatabaseCleaner.deprecate "Calling `DatabaseCleaner.init_cleaners` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
     end
 
     def connections
       if called_externally?(caller)
-        $stderr.puts "Calling `DatabaseCleaner.connections` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.cleaners`, instead."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner.connections` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.cleaners`, instead."
       end
       add_cleaner(:autodetect) if @cleaners.none?
       @cleaners.values
@@ -107,14 +108,14 @@ module DatabaseCleaner
 
     def add_cleaner(orm, opts = {})
       if called_externally?(caller)
-        $stderr.puts "Calling `DatabaseCleaner.add_cleaner` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.[]`, instead."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner.add_cleaner` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.[]`, instead."
       end
       @cleaners.add_cleaner(orm, opts = {})
     end
 
     def remove_duplicates
       if called_externally?(caller)
-        $stderr.puts "Calling `DatabaseCleaner.remove_duplicates` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner.remove_duplicates` is deprecated, and will be removed in database_cleaner 2.0 with no replacement."
       end
       @cleaners.remove_duplicates
     end

--- a/lib/database_cleaner/deprecation.rb
+++ b/lib/database_cleaner/deprecation.rb
@@ -1,0 +1,21 @@
+module DatabaseCleaner
+  def deprecate message
+    method = caller.first[/\d+:in `(.*)'$/, 1].to_sym
+    @@deprecator ||= Deprecator.new
+    @@deprecator.deprecate method, message
+  end
+  module_function :deprecate
+
+  class Deprecator
+    def initialize
+      @methods_already_warned = {}
+    end
+
+    def deprecate method, message
+      return if @methods_already_warned.key?(method)
+      $stderr.puts message
+      @methods_already_warned[method] = true
+    end
+  end
+end
+


### PR DESCRIPTION
DatabaseCleaner's public API contains many methods that are just used for internal bookkeeping or implementation, and should have been private methods. Since privatizing a method is a breaking change, we need to deprecate usage of these methods before privatizing or removing them in v2.0. I don't expect anyone is actually using this methods, because they're undocumented, and not of much utility on their own, but its possible.

There's also a few methods that are old undocumented aliases for other methods, so let's deprecate those, too, while we're at it!