### PR TITLE
Add .default_strategy method to all adapters, and move knowledge into it from core

### DIFF
--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/base.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/base.rb
@@ -4,9 +4,12 @@ require 'erb'
 
 module DatabaseCleaner
   module ActiveRecord
-
     def self.available_strategies
       %w[truncation transaction deletion]
+    end
+
+    def self.default_strategy
+      :transaction
     end
 
     def self.config_file_location=(path)

--- a/adapters/database_cleaner-active_record/spec/database_cleaner/active_record/base_spec.rb
+++ b/adapters/database_cleaner-active_record/spec/database_cleaner/active_record/base_spec.rb
@@ -11,6 +11,10 @@ end
 RSpec.describe DatabaseCleaner::ActiveRecord do
   it { is_expected.to respond_to(:available_strategies) }
 
+  it "has a default_strategy of transaction" do
+    expect(described_class.default_strategy).to eq(:transaction)
+  end
+
   describe "config_file_location" do
     after do
       # prevent global state leakage

--- a/adapters/database_cleaner-couch_potato/lib/database_cleaner/couch_potato.rb
+++ b/adapters/database_cleaner-couch_potato/lib/database_cleaner/couch_potato.rb
@@ -3,3 +3,9 @@ require "database_cleaner"
 require "database_cleaner/couch_potato/base"
 require "database_cleaner/couch_potato/truncation"
 
+module DatabaseCleaner::CouchPotato
+  def self.default_strategy
+    :truncation
+  end
+end
+

--- a/adapters/database_cleaner-couch_potato/spec/database_cleaner/couch_potato/base_spec.rb
+++ b/adapters/database_cleaner-couch_potato/spec/database_cleaner/couch_potato/base_spec.rb
@@ -1,0 +1,8 @@
+require 'database_cleaner/couch_potato'
+
+RSpec.describe DatabaseCleaner::CouchPotato do
+  it "has a default_strategy of truncation" do
+    expect(described_class.default_strategy).to eq(:truncation)
+  end
+end
+

--- a/adapters/database_cleaner-data_mapper/lib/database_cleaner/data_mapper/base.rb
+++ b/adapters/database_cleaner-data_mapper/lib/database_cleaner/data_mapper/base.rb
@@ -5,6 +5,10 @@ module DatabaseCleaner
       %w[truncation transaction]
     end
 
+    def self.default_strategy
+      :transaction
+    end
+
     module Base
       include ::DatabaseCleaner::Generic::Base
 

--- a/adapters/database_cleaner-data_mapper/spec/database_cleaner/data_mapper/base_spec.rb
+++ b/adapters/database_cleaner-data_mapper/spec/database_cleaner/data_mapper/base_spec.rb
@@ -4,6 +4,10 @@ require 'database_cleaner/spec'
 module DatabaseCleaner
   RSpec.describe DataMapper do
     it { is_expected.to respond_to(:available_strategies) }
+
+    it "has a default_strategy of transaction" do
+      expect(described_class.default_strategy).to eq(:transaction)
+    end
   end
 
   module DataMapper

--- a/adapters/database_cleaner-mongo/lib/database_cleaner/mongo.rb
+++ b/adapters/database_cleaner-mongo/lib/database_cleaner/mongo.rb
@@ -1,3 +1,10 @@
 require 'database_cleaner/mongo/version'
 require 'database_cleaner'
 require 'database_cleaner/mongo/truncation'
+
+module DatabaseCleaner::Mongo
+  def self.default_strategy
+    :truncation
+  end
+end
+

--- a/adapters/database_cleaner-mongo/spec/database_cleaner/mongo/base_spec.rb
+++ b/adapters/database_cleaner-mongo/spec/database_cleaner/mongo/base_spec.rb
@@ -1,0 +1,8 @@
+require 'database_cleaner/mongo'
+
+RSpec.describe DatabaseCleaner::Mongo do
+  it "has a default_strategy of truncation" do
+    expect(described_class.default_strategy).to eq(:truncation)
+  end
+end
+

--- a/adapters/database_cleaner-mongo_mapper/lib/database_cleaner/mongo_mapper/base.rb
+++ b/adapters/database_cleaner-mongo_mapper/lib/database_cleaner/mongo_mapper/base.rb
@@ -5,6 +5,10 @@ module DatabaseCleaner
       %w[truncation]
     end
 
+    def self.default_strategy
+      :truncation
+    end
+
     module Base
       include ::DatabaseCleaner::Generic::Base
 

--- a/adapters/database_cleaner-mongo_mapper/spec/database_cleaner/mongo_mapper/base_spec.rb
+++ b/adapters/database_cleaner-mongo_mapper/spec/database_cleaner/mongo_mapper/base_spec.rb
@@ -4,6 +4,10 @@ require 'database_cleaner/spec'
 module DatabaseCleaner
   RSpec.describe MongoMapper do
     it { is_expected.to respond_to(:available_strategies) }
+
+    it "has a default_strategy of truncation" do
+      expect(described_class.default_strategy).to eq(:truncation)
+    end
   end
 
   module MongoMapper

--- a/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid.rb
+++ b/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid.rb
@@ -1,3 +1,10 @@
 require "database_cleaner/mongoid/version"
 require "database_cleaner"
 require "database_cleaner/mongoid/truncation"
+
+module DatabaseCleaner::Mongoid
+  def self.default_strategy
+    :truncation
+  end
+end
+

--- a/adapters/database_cleaner-mongoid/spec/database_cleaner/mongoid/base_spec.rb
+++ b/adapters/database_cleaner-mongoid/spec/database_cleaner/mongoid/base_spec.rb
@@ -1,0 +1,8 @@
+require 'database_cleaner/mongoid'
+
+RSpec.describe DatabaseCleaner::Mongoid do
+  it "has a default_strategy of truncation" do
+    expect(described_class.default_strategy).to eq(:truncation)
+  end
+end
+

--- a/adapters/database_cleaner-moped/lib/database_cleaner/moped.rb
+++ b/adapters/database_cleaner-moped/lib/database_cleaner/moped.rb
@@ -2,3 +2,9 @@ require "database_cleaner/moped/version"
 require "database_cleaner"
 require "database_cleaner/moped/truncation"
 
+module DatabaseCleaner::Moped
+  def self.default_strategy
+    :truncation
+  end
+end
+

--- a/adapters/database_cleaner-moped/spec/database_cleaner/moped/base_spec.rb
+++ b/adapters/database_cleaner-moped/spec/database_cleaner/moped/base_spec.rb
@@ -1,0 +1,8 @@
+require 'database_cleaner/moped'
+
+RSpec.describe DatabaseCleaner::Moped do
+  it "has a default_strategy of truncation" do
+    expect(described_class.default_strategy).to eq(:truncation)
+  end
+end
+

--- a/adapters/database_cleaner-neo4j/lib/database_cleaner/neo4j/base.rb
+++ b/adapters/database_cleaner-neo4j/lib/database_cleaner/neo4j/base.rb
@@ -5,6 +5,10 @@ module DatabaseCleaner
       %w[transaction truncation deletion]
     end
 
+    def self.default_strategy
+      :transaction
+    end
+
     module Base
       include ::DatabaseCleaner::Generic::Base
 

--- a/adapters/database_cleaner-neo4j/spec/database_cleaner/neo4j/base_spec.rb
+++ b/adapters/database_cleaner-neo4j/spec/database_cleaner/neo4j/base_spec.rb
@@ -4,6 +4,10 @@ require 'database_cleaner/spec'
 module DatabaseCleaner
   RSpec.describe Neo4j do
     it { is_expected.to respond_to(:available_strategies) }
+
+    it "has a default_strategy of transaction" do
+      expect(described_class.default_strategy).to eq(:transaction)
+    end
   end
 
   module Neo4j

--- a/adapters/database_cleaner-ohm/lib/database_cleaner/ohm.rb
+++ b/adapters/database_cleaner-ohm/lib/database_cleaner/ohm.rb
@@ -2,3 +2,9 @@ require "database_cleaner/ohm/version"
 require "database_cleaner"
 require "database_cleaner/ohm/truncation"
 
+module DatabaseCleaner::Ohm
+  def self.default_strategy
+    :truncation
+  end
+end
+

--- a/adapters/database_cleaner-ohm/spec/database_cleaner/ohm/base_spec.rb
+++ b/adapters/database_cleaner-ohm/spec/database_cleaner/ohm/base_spec.rb
@@ -1,0 +1,8 @@
+require 'database_cleaner/ohm'
+
+RSpec.describe DatabaseCleaner::Ohm do
+  it "has a default_strategy of truncation" do
+    expect(described_class.default_strategy).to eq(:truncation)
+  end
+end
+

--- a/adapters/database_cleaner-redis/lib/database_cleaner/redis/base.rb
+++ b/adapters/database_cleaner-redis/lib/database_cleaner/redis/base.rb
@@ -6,6 +6,10 @@ module DatabaseCleaner
       %w{truncation}
     end
 
+    def self.default_strategy
+      :truncation
+    end
+
     module Base
       include ::DatabaseCleaner::Generic::Base
 

--- a/adapters/database_cleaner-redis/spec/database_cleaner/redis/base_spec.rb
+++ b/adapters/database_cleaner-redis/spec/database_cleaner/redis/base_spec.rb
@@ -5,6 +5,10 @@ require 'database_cleaner/spec'
 module DatabaseCleaner
   RSpec.describe Redis do
     it { is_expected.to respond_to(:available_strategies) }
+
+    it "has a default_strategy of truncation" do
+      expect(described_class.default_strategy).to eq(:truncation)
+    end
   end
 
   module Redis

--- a/adapters/database_cleaner-sequel/lib/database_cleaner/sequel/base.rb
+++ b/adapters/database_cleaner-sequel/lib/database_cleaner/sequel/base.rb
@@ -5,6 +5,10 @@ module DatabaseCleaner
       %w(truncation transaction deletion)
     end
 
+    def self.default_strategy
+      :transaction
+    end
+
     module Base
       include ::DatabaseCleaner::Generic::Base
 

--- a/adapters/database_cleaner-sequel/spec/database_cleaner/sequel/base_spec.rb
+++ b/adapters/database_cleaner-sequel/spec/database_cleaner/sequel/base_spec.rb
@@ -5,6 +5,10 @@ require 'sequel'
 module DatabaseCleaner
   RSpec.describe Sequel do
     it { is_expected.to respond_to(:available_strategies) }
+
+    it "has a default_strategy of transaction" do
+      expect(described_class.default_strategy).to eq(:transaction)
+    end
   end
 
   module Sequel


### PR DESCRIPTION
Core shouldn't even know about what adapters are out there in the wild, much less what their specific preferences are.

The removed method `DatabaseCleaner::Base#default_orm_strategy` was private, so this is a non-breaking change.