### PR TITLE
Deprecate DC.app_root setting, since it's only used in DC::AR.config_file_location.

### DIFF
--- a/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/base.rb
+++ b/adapters/database_cleaner-active_record/lib/database_cleaner/active_record/base.rb
@@ -14,7 +14,12 @@ module DatabaseCleaner
     end
 
     def self.config_file_location
-      @config_file_location ||= "#{DatabaseCleaner.app_root}/config/database.yml"
+      @config_file_location ||= begin
+        # Has DC.app_root been set? Check in this intrusive way to avoid triggering deprecation warnings if it hasn't.
+        app_root = DatabaseCleaner.send(:configuration).instance_variable_get(:@app_root)
+        root = app_root || Dir.pwd
+        "#{root}/config/database.yml"
+      end
     end
 
     module Base

--- a/lib/database_cleaner/configuration.rb
+++ b/lib/database_cleaner/configuration.rb
@@ -54,10 +54,16 @@ module DatabaseCleaner
       :remove_duplicates,
     ] => :cleaners
 
-    attr_accessor :app_root, :logger, :cleaners
+    attr_accessor :logger, :cleaners
 
     def app_root
+      $stderr.puts "Calling `DatabaseCleaner.app_root` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner::ActiveRecord.config_file_location`, instead."
       @app_root ||= Dir.pwd
+    end
+
+    def app_root= value
+      $stderr.puts "Calling `DatabaseCleaner.app_root=` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner::ActiveRecord.config_file_location=`, instead."
+      @app_root = value
     end
 
     def logger


### PR DESCRIPTION
Closes #555. See issue for more details.