### PR TITLE
Remove undeclared active_support dependency. Fixes: #611

### DIFF
--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -2,7 +2,6 @@ require 'database_cleaner/deprecation'
 require 'database_cleaner/null_strategy'
 require 'database_cleaner/safeguard'
 require 'database_cleaner/orm_autodetector'
-require 'active_support/core_ext/string/inflections'
 require 'forwardable'
 
 module DatabaseCleaner
@@ -119,11 +118,13 @@ module DatabaseCleaner
       return unless [:active_record, :data_mapper, :mongo, :mongoid, :mongo_mapper, :moped, :couch_potato, :sequel, :ohm, :redis, :neo4j].include?(orm)
       $LOAD_PATH.unshift File.expand_path("#{File.dirname(__FILE__)}/../../adapters/database_cleaner-#{orm}/lib")
       require "database_cleaner/#{orm}"
-      DatabaseCleaner.const_get(orm.to_s.camelize)
+      orm_module_name = ORMAutodetector::ORMS[orm]
+      DatabaseCleaner.const_get(orm_module_name)
     end
 
     def orm_strategy(strategy)
-      orm_module.const_get(strategy.to_s.capitalize)
+      strategy_module_name = strategy.to_s.capitalize
+      orm_module.const_get(strategy_module_name)
     rescue NameError
       if orm != :active_record
         DatabaseCleaner.deprecate <<-TEXT

--- a/lib/database_cleaner/orm_autodetector.rb
+++ b/lib/database_cleaner/orm_autodetector.rb
@@ -1,13 +1,22 @@
-require 'active_support/core_ext/string/inflections'
-
 module DatabaseCleaner
   class ORMAutodetector
-    ORMS = %w[ActiveRecord DataMapper MongoMapper Mongoid CouchPotato Sequel Moped Ohm Redis Neo4j]
+    ORMS = {
+      active_record: "ActiveRecord",
+      data_mapper: "DataMapper",
+      mongo_mapper: "MongoMapper",
+      mongoid: "Mongoid",
+      couch_potato: "CouchPotato",
+      sequel: "Sequel",
+      moped: "Moped",
+      ohm: "Ohm",
+      redis: "Redis",
+      neo4j: "Neo4j",
+    }
 
     def orm
       @autodetected = true
       autodetected_orm or raise no_orm_detected_error
-      autodetected_orm.underscore.to_sym
+      ORMS.key(autodetected_orm.to_s)
     end
 
     def autodetected?
@@ -17,13 +26,13 @@ module DatabaseCleaner
     private
 
     def autodetected_orm
-      ORMS.find do |orm|
+      ORMS.values.find do |orm|
         Kernel.const_get(orm) rescue next
       end
     end
 
     def no_orm_detected_error
-      orm_list = ORMS.join(", ").sub(ORMS.last, "or #{ORMS.last}")
+      orm_list = ORMS.values.join(", ").sub(ORMS.values.last, "or #{ORMS.values.last}")
       NoORMDetected.new("No known ORM was detected!  Is #{orm_list} loaded?")
     end
   end


### PR DESCRIPTION
Turns out v1.8.0 introduced an undeclared dependency on active_support. We do not wish to make active_support a dependency of database_cleaner, so lets get rid of it!