### PR TITLE
README: Add Markdown link to LICENSE

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -384,4 +384,4 @@ DatabaseCleaner.url_whitelist = ['postgres://postgres@localhost', 'postgres://fo
 
 ## COPYRIGHT
 
-See [LICENSE] for details.
+See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
This PR repairs a broken Markdown link to the LICENSE.