### PR TITLE
Inline mongoid adapter dependencies. Closes #616

### DIFF
--- a/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/mongo1_truncation_mixin.rb
+++ b/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/mongo1_truncation_mixin.rb
@@ -1,0 +1,26 @@
+module DatabaseCleaner
+  module Mongoid
+    module Mongo1TruncationMixin
+      def clean
+        if @only
+          collections.each { |c| c.send(truncate_method_name) if @only.include?(c.name) }
+        else
+          collections.each { |c| c.send(truncate_method_name) unless @tables_to_exclude.include?(c.name) }
+        end
+        true
+      end
+
+      private
+
+      def collections
+        database.collections.select { |c| c.name !~ /^system\./ }
+      end
+
+      def truncate_method_name
+        # This constant only exists in the 2.x series.
+        defined?(::Mongo::VERSION) ? :delete_many : :remove
+      end
+    end
+  end
+end
+

--- a/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/mongo2_truncation_mixin.rb
+++ b/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/mongo2_truncation_mixin.rb
@@ -1,7 +1,6 @@
 module DatabaseCleaner
-  module Mongo2
-    module TruncationMixin
-
+  module Mongoid
+    module Mongo2TruncationMixin
       def clean
         if @only
           collections.each { |c| database[c].find.delete_many if @only.include?(c) }
@@ -33,7 +32,7 @@ module DatabaseCleaner
         #   name
         # end
       end
-
     end
   end
 end
+

--- a/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/mongoid_truncation_mixin.rb
+++ b/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/mongoid_truncation_mixin.rb
@@ -1,0 +1,65 @@
+require 'database_cleaner/generic/base'
+require 'database_cleaner/generic/truncation'
+
+module DatabaseCleaner
+  module Mongoid
+    module MongoidTruncationMixin
+      include ::DatabaseCleaner::Generic::Base
+      include ::DatabaseCleaner::Generic::Truncation
+
+      def db=(desired_db)
+        @db = desired_db
+      end
+
+      def db
+        @db ||= :default
+      end
+
+      def host_port=(desired_host)
+        @host = desired_host
+      end
+
+      def host
+        @host ||= '127.0.0.1:27017'
+      end
+
+      def db_version
+        @db_version ||= session.command('buildinfo' => 1)['version']
+      end
+
+      def clean
+        if @only
+          collections.each { |c| session[c].find.remove_all if @only.include?(c) }
+        else
+          collections.each { |c| session[c].find.remove_all unless @tables_to_exclude.include?(c) }
+        end
+        wait_for_removals_to_finish
+        true
+      end
+
+      private
+
+      def collections
+        if db != :default
+          session.use(db)
+        end
+
+        if db_version.split('.').first.to_i >= 3
+          session.command(listCollections: 1, filter: { 'name' => { '$not' => /.?system\.|\$/ } })['cursor']['firstBatch'].map do |collection|
+            collection['name']
+          end
+        else
+          session['system.namespaces'].find(name: { '$not' => /\.system\.|\$/ }).to_a.map do |collection|
+            _, name = collection['name'].split('.', 2)
+            name
+          end
+        end
+      end
+
+      def wait_for_removals_to_finish
+        session.command(getlasterror: 1)
+      end
+    end
+  end
+end
+

--- a/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/truncation.rb
+++ b/adapters/database_cleaner-mongoid/lib/database_cleaner/mongoid/truncation.rb
@@ -1,8 +1,8 @@
 require 'database_cleaner/mongoid/base'
 require 'database_cleaner/generic/truncation'
-require 'database_cleaner/mongo/truncation_mixin'
-require 'database_cleaner/mongo2/truncation_mixin'
-require 'database_cleaner/moped/truncation_base'
+require 'database_cleaner/mongoid/mongo1_truncation_mixin'
+require 'database_cleaner/mongoid/mongo2_truncation_mixin'
+require 'database_cleaner/mongoid/mongoid_truncation_mixin'
 require 'mongoid/version'
 
 module DatabaseCleaner
@@ -13,7 +13,7 @@ module DatabaseCleaner
 
       if ::Mongoid::VERSION < '3'
 
-        include ::DatabaseCleaner::Mongo::TruncationMixin
+        include ::DatabaseCleaner::Mongoid::Mongo1TruncationMixin
 
         private
 
@@ -23,7 +23,7 @@ module DatabaseCleaner
 
       elsif ::Mongoid::VERSION < '5'
 
-        include ::DatabaseCleaner::Moped::TruncationBase
+        include ::DatabaseCleaner::Mongoid::MongoidTruncationMixin
 
         private
 
@@ -41,7 +41,7 @@ module DatabaseCleaner
 
       else
 
-        include ::DatabaseCleaner::Mongo2::TruncationMixin
+        include ::DatabaseCleaner::Mongoid::Mongo2TruncationMixin
 
       end
     end


### PR DESCRIPTION
As described in #616, the mongoid adapter actually depends on the internals of other adapters for its own implementation. This was not a problem until we isolated the adapters to split them off into their own gems.

The solution here is to copy these various implementations into the mongoid adapter itself. This introduces some duplication, to be sure, but I expect that most of this code will be deleted in the DatabaseCleaner 2.0, when we start testing against modern implementations, so I think its okay.