### PR TITLE
Fix and deprecate Ohm adapter

### DIFF
--- a/adapters/database_cleaner-ohm/lib/database_cleaner/ohm.rb
+++ b/adapters/database_cleaner-ohm/lib/database_cleaner/ohm.rb
@@ -2,6 +2,8 @@ require "database_cleaner/ohm/version"
 require "database_cleaner"
 require "database_cleaner/ohm/truncation"
 
+DatabaseCleaner.deprecate "The Ohm adapter for DatabaseCleaner is deprecated, and will be removed in v2.0. Please use the Redis adapter instead."
+
 module DatabaseCleaner::Ohm
   def self.default_strategy
     :truncation

--- a/adapters/database_cleaner-ohm/lib/database_cleaner/ohm/truncation.rb
+++ b/adapters/database_cleaner-ohm/lib/database_cleaner/ohm/truncation.rb
@@ -1,4 +1,9 @@
-require 'database_cleaner/redis/truncation'
+begin # when database_cleaner-ohm is loaded as a gem
+  require 'database_cleaner/redis/truncation'
+rescue LoadError # when database_cleaner is loaded as a gem
+  $LOAD_PATH.unshift File.expand_path("#{File.dirname(__FILE__)}/../../../../../adapters/database_cleaner-redis/lib")
+  require 'database_cleaner/redis/truncation'
+end
 
 module DatabaseCleaner
   module Ohm


### PR DESCRIPTION
Fixes Ohm adapter load issue in `database_cleaner` gem, and deprecates the adapter entirely, in favor of the Redis adapter, since the two are functionally identical. Closes #618