### PR TITLE
Fix performance issue of DatabaseCleaner::Base#orm_module

### DIFF
--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -116,10 +116,12 @@ module DatabaseCleaner
 
     def orm_module
       return unless [:active_record, :data_mapper, :mongo, :mongoid, :mongo_mapper, :moped, :couch_potato, :sequel, :ohm, :redis, :neo4j].include?(orm)
+      orm_module_name = ORMAutodetector::ORMS[orm]
+      DatabaseCleaner.const_get(orm_module_name, false)
+    rescue NameError
       $LOAD_PATH.unshift File.expand_path("#{File.dirname(__FILE__)}/../../adapters/database_cleaner-#{orm}/lib")
       require "database_cleaner/#{orm}"
-      orm_module_name = ORMAutodetector::ORMS[orm]
-      DatabaseCleaner.const_get(orm_module_name)
+      retry
     end
 
     def orm_strategy(strategy)


### PR DESCRIPTION
This pull request fixes a performance degradation that ultimately caused DatabaseCleaner.strategy= to be very slow. Instead of requiring the correct gem for the given orm every time it is called, it first tries to get the constant and only requires the gem if the constant is missing.

The implementation is similar to how `DatabaseCleaner::Base#orm_strategy` works.

This pull request closes #624