### PR TITLE
Add shared example for database_cleaner adapter

### DIFF
--- a/lib/database_cleaner/spec/shared_examples.rb
+++ b/lib/database_cleaner/spec/shared_examples.rb
@@ -13,3 +13,12 @@ RSpec.shared_examples_for "a generic transaction strategy" do
   it { is_expected.to respond_to(:clean) }
   it { is_expected.to respond_to(:cleaning) }
 end
+
+RSpec.shared_examples_for "a database_cleaner adapter" do
+  it { expect(described_class).to respond_to(:available_strategies) }
+  it { expect(described_class).to respond_to(:default_strategy) }
+
+  it 'default_strategy should be part of available_strategies' do
+    expect(described_class.available_strategies).to include(described_class.default_strategy)
+  end
+end


### PR DESCRIPTION
Following the discussion https://github.com/DatabaseCleaner/database_cleaner/issues/628
This pr adds shared examples for a generic adapter