### PR TITLE
Drop support for Ruby 2.4, which is EOL as of 2020-03-31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7


### PR DESCRIPTION
Source: https://www.ruby-lang.org/en/downloads/branches/

Even though this EOL happened only a week ago, I think its a good idea to do this now, before the 2.0.0 release, otherwise we'll be stuck with it until 3.0.0.