### PR TITLE
Rename DC::Base to DC::Cleaner.

### DIFF
--- a/lib/database_cleaner/cleaner.rb
+++ b/lib/database_cleaner/cleaner.rb
@@ -6,7 +6,7 @@ require 'forwardable'
 module DatabaseCleaner
   class UnknownStrategySpecified < ArgumentError; end
 
-  class Base
+  class Cleaner
     include Comparable
 
     def <=>(other)

--- a/lib/database_cleaner/cleaners.rb
+++ b/lib/database_cleaner/cleaners.rb
@@ -1,4 +1,4 @@
-require 'database_cleaner/base'
+require 'database_cleaner/cleaner'
 
 module DatabaseCleaner
   class Cleaners < Hash
@@ -43,7 +43,7 @@ module DatabaseCleaner
     private
 
     def add_cleaner(orm, opts = {})
-      self[[orm, opts]] = ::DatabaseCleaner::Base.new(orm, opts)
+      self[[orm, opts]] = Cleaner.new(orm, opts)
     end
 
     def remove_duplicates

--- a/spec/database_cleaner/cleaner_spec.rb
+++ b/spec/database_cleaner/cleaner_spec.rb
@@ -1,25 +1,25 @@
 module DatabaseCleaner
-  RSpec.describe Base do
+  RSpec.describe Cleaner do
     describe "comparison" do
       it "should be equal if orm and connection are the same" do
-        one = Base.new(:active_record, connection: :default)
-        two = Base.new(:active_record, connection: :default)
+        one = Cleaner.new(:active_record, connection: :default)
+        two = Cleaner.new(:active_record, connection: :default)
 
         expect(one).to eq two
         expect(two).to eq one
       end
 
       it "should not be equal if orm are not the same" do
-        one = Base.new(:mongo_id, connection: :default)
-        two = Base.new(:active_record, connection: :default)
+        one = Cleaner.new(:mongo_id, connection: :default)
+        two = Cleaner.new(:active_record, connection: :default)
 
         expect(one).not_to eq two
         expect(two).not_to eq one
       end
 
       it "should not be equal if connection are not the same" do
-        one = Base.new(:active_record, connection: :default)
-        two = Base.new(:active_record, connection: :other)
+        one = Cleaner.new(:active_record, connection: :default)
+        two = Cleaner.new(:active_record, connection: :other)
 
         expect(one).not_to eq two
         expect(two).not_to eq one
@@ -28,7 +28,7 @@ module DatabaseCleaner
 
     describe "initialization" do
       context "db specified" do
-        subject(:cleaner) { Base.new(:active_record, connection: :my_db) }
+        subject(:cleaner) { Cleaner.new(:active_record, connection: :my_db) }
 
         it "should store db from :connection in params hash" do
           expect(cleaner.db).to eq :my_db
@@ -37,29 +37,29 @@ module DatabaseCleaner
 
       describe "orm" do
         it "should store orm" do
-          cleaner = Base.new(:a_orm)
+          cleaner = Cleaner.new(:a_orm)
           expect(cleaner.orm).to eq :a_orm
         end
 
         it "converts string to symbols" do
-          cleaner = Base.new("mongoid")
+          cleaner = Cleaner.new("mongoid")
           expect(cleaner.orm).to eq :mongoid
         end
 
         it "should default to :null" do
-          cleaner = Base.new
+          cleaner = Cleaner.new
           expect(cleaner.orm).to eq :null
         end
 
         it "raises ArgumentError when explicitly set to nil" do
-          cleaner = Base.new
+          cleaner = Cleaner.new
           expect { cleaner.orm = nil }.to raise_error(ArgumentError)
         end
       end
     end
 
     describe "db" do
-      subject(:cleaner) { Base.new }
+      subject(:cleaner) { Cleaner.new }
 
       it "should default to :default" do
         expect(cleaner.db).to eq :default
@@ -72,7 +72,7 @@ module DatabaseCleaner
     end
 
     describe "db=" do
-      subject(:cleaner) { Base.new }
+      subject(:cleaner) { Cleaner.new }
 
       context "when strategy supports db specification" do
         it "should pass db down to its current strategy" do
@@ -98,7 +98,7 @@ module DatabaseCleaner
     end
 
     describe "clean_with" do
-      subject(:cleaner) { Base.new(:active_record) }
+      subject(:cleaner) { Cleaner.new(:active_record) }
 
       let(:strategy_class) { Class.new }
       let(:strategy) { double }
@@ -126,7 +126,7 @@ module DatabaseCleaner
     end
 
     describe "strategy=" do
-      subject(:cleaner) { Base.new(:active_record) }
+      subject(:cleaner) { Cleaner.new(:active_record) }
 
       let(:strategy_class) { Class.new }
 
@@ -175,7 +175,7 @@ module DatabaseCleaner
     end
 
     describe "strategy" do
-      subject(:cleaner) { Base.new(:a_orm) }
+      subject(:cleaner) { Cleaner.new(:a_orm) }
 
       it "returns a null strategy when strategy is not set and undetectable" do
         expect(cleaner.strategy).to be_a(DatabaseCleaner::NullStrategy)
@@ -186,14 +186,14 @@ module DatabaseCleaner
       let(:mock_orm) { double("orm") }
 
       it "should return orm if orm set" do
-        cleaner = Base.new
+        cleaner = Cleaner.new
         cleaner.orm = :desired_orm
         expect(cleaner.orm).to eq :desired_orm
       end
     end
 
     describe "proxy methods" do
-      subject(:cleaner) { Base.new }
+      subject(:cleaner) { Cleaner.new }
 
       let(:strategy) { double(:strategy) }
 

--- a/spec/database_cleaner/cleaners_spec.rb
+++ b/spec/database_cleaner/cleaners_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DatabaseCleaner::Cleaners do
 
     it "should accept :active_record" do
       cleaner = cleaners[:active_record]
-      expect(cleaner).to be_a(DatabaseCleaner::Base)
+      expect(cleaner).to be_a(DatabaseCleaner::Cleaner)
       expect(cleaner.orm).to eq :active_record
       expect(cleaners.values).to eq [cleaner]
     end
@@ -21,7 +21,7 @@ RSpec.describe DatabaseCleaner::Cleaners do
 
     it "should accept a connection parameter and store it" do
       cleaner = cleaners[:active_record, connection: :first_connection]
-      expect(cleaner).to be_a(DatabaseCleaner::Base)
+      expect(cleaner).to be_a(DatabaseCleaner::Cleaner)
       expect(cleaner.orm).to eq :active_record
       expect(cleaner.db).to eq :first_connection
     end

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -1,6 +1,6 @@
 module DatabaseCleaner
   RSpec.describe Safeguard do
-    let(:cleaner)  { Base.new(:null) }
+    let(:cleaner)  { Cleaner.new(:null) }
 
     describe 'DATABASE_URL is set' do
       before { stub_const('ENV', 'DATABASE_URL' => database_url) }


### PR DESCRIPTION
Improve the naming of `DatabaseCleaner::Base`. This class is never subclassed by anything, so "Base" is a misleading name, and not otherwise intention-revealing. This class is a single entry in the `DatabaseCleaner::Cleaners` collection, and is responsible for keeping track of the selected ORM and Strategy, and delegating cleaning commands down to it, so I think "Cleaner" is the most appropriate name here. We're already even calling instances of this thing `cleaner` in the code.

While this is technically a breaking change, since `DatabaseCleaner::Base` was a publicly available constant, no ORM adapter references it; its usage was entirely internal. Therefore I think this can be viewed as a refactoring. Either way, the next release is a major version bump to 2.0, so I think we're covered.