### PR TITLE
[BREAKING CHANGE] Remove all #orm= setter methods

### DIFF
--- a/lib/database_cleaner/cleaner.rb
+++ b/lib/database_cleaner/cleaner.rb
@@ -13,11 +13,13 @@ module DatabaseCleaner
       [orm, db] <=> [other.orm, other.db]
     end
 
-    def initialize(orm = :null, opts = {})
-      self.orm = orm
+    def initialize(orm, opts = {})
+      @orm = orm
       self.db = opts[:connection] || opts[:model] if opts.has_key?(:connection) || opts.has_key?(:model)
       Safeguard.new.run
     end
+
+    attr_reader :orm
 
     def db=(desired_db)
       @db = self.strategy_db = desired_db
@@ -42,13 +44,6 @@ module DatabaseCleaner
 
     def strategy
       @strategy ||= NullStrategy.new
-    end
-
-    attr_reader :orm
-
-    def orm= orm
-      raise ArgumentError if orm.nil?
-      @orm = orm.to_sym
     end
 
     extend Forwardable

--- a/lib/database_cleaner/cleaners.rb
+++ b/lib/database_cleaner/cleaners.rb
@@ -17,11 +17,6 @@ module DatabaseCleaner
       remove_duplicates
     end
 
-    def orm=(orm)
-      values.each { |cleaner| cleaner.orm = orm }
-      remove_duplicates
-    end
-
     def start
       values.each { |connection| connection.start }
     end

--- a/lib/database_cleaner/core.rb
+++ b/lib/database_cleaner/core.rb
@@ -8,7 +8,6 @@ module DatabaseCleaner
     delegate [
       :[],
       :strategy=,
-      :orm=,
       :start,
       :clean,
       :clean_with,

--- a/spec/database_cleaner/cleaner_spec.rb
+++ b/spec/database_cleaner/cleaner_spec.rb
@@ -41,25 +41,14 @@ module DatabaseCleaner
           expect(cleaner.orm).to eq :a_orm
         end
 
-        it "converts string to symbols" do
-          cleaner = Cleaner.new("mongoid")
-          expect(cleaner.orm).to eq :mongoid
-        end
-
-        it "should default to :null" do
-          cleaner = Cleaner.new
-          expect(cleaner.orm).to eq :null
-        end
-
-        it "raises ArgumentError when explicitly set to nil" do
-          cleaner = Cleaner.new
-          expect { cleaner.orm = nil }.to raise_error(ArgumentError)
+        it "raises ArgumentError when no orm is specified" do
+          expect { Cleaner.new }.to raise_error(ArgumentError)
         end
       end
     end
 
     describe "db" do
-      subject(:cleaner) { Cleaner.new }
+      subject(:cleaner) { Cleaner.new(:orm) }
 
       it "should default to :default" do
         expect(cleaner.db).to eq :default
@@ -72,7 +61,7 @@ module DatabaseCleaner
     end
 
     describe "db=" do
-      subject(:cleaner) { Cleaner.new }
+      subject(:cleaner) { Cleaner.new(:orm) }
 
       context "when strategy supports db specification" do
         it "should pass db down to its current strategy" do
@@ -182,18 +171,8 @@ module DatabaseCleaner
       end
     end
 
-    describe "orm" do
-      let(:mock_orm) { double("orm") }
-
-      it "should return orm if orm set" do
-        cleaner = Cleaner.new
-        cleaner.orm = :desired_orm
-        expect(cleaner.orm).to eq :desired_orm
-      end
-    end
-
     describe "proxy methods" do
-      subject(:cleaner) { Cleaner.new }
+      subject(:cleaner) { Cleaner.new(:orm) }
 
       let(:strategy) { double(:strategy) }
 

--- a/spec/database_cleaner/cleaners_spec.rb
+++ b/spec/database_cleaner/cleaners_spec.rb
@@ -63,12 +63,6 @@ RSpec.describe DatabaseCleaner::Cleaners do
         cleaners.strategy = stratagem
       end
 
-      it "should proxy orm=" do
-        orm = double("orm")
-        expect(cleaner).to receive(:orm=).with(orm)
-        cleaners.orm = orm
-      end
-
       it "should proxy start" do
         expect(cleaner).to receive(:start)
         cleaners.start
@@ -103,13 +97,6 @@ RSpec.describe DatabaseCleaner::Cleaners do
             active_record: active_record,
             data_mapper: data_mapper,
           })
-        end
-
-        it "should proxy orm to all cleaners" do
-          expect(active_record).to receive(:orm=)
-          expect(data_mapper).to receive(:orm=)
-
-          cleaners.orm = :orm
         end
 
         it "should proxy start to all cleaners" do
@@ -163,30 +150,9 @@ RSpec.describe DatabaseCleaner::Cleaners do
       end
 
       # ah now we have some difficulty, we mustn't allow duplicate cleaners to exist, but they could
-      # plausably want to force orm/strategy change on two sets of orm that differ only on db
+      # plausably want to force strategy change on two sets of orm that differ only on db
       context "multiple orm proxy methods" do
         class FakeStrategy < Struct.new(:orm, :db, :strategy); end
-
-        context "with differing orms and dbs" do
-          let(:active_record_1) { FakeStrategy.new(:active_record) }
-          let(:active_record_2) { FakeStrategy.new(:active_record, :different) }
-          let(:data_mapper_1)   { FakeStrategy.new(:data_mapper) }
-
-          subject(:cleaners) do
-            DatabaseCleaner::Cleaners.new({
-              active_record_1: active_record_1,
-              active_record_2: active_record_2,
-              data_mapper_1: data_mapper_1,
-            })
-          end
-
-          it "should proxy #orm= to all cleaners and remove duplicate cleaners" do
-            expect { cleaners.orm = :data_mapper }
-              .to change { cleaners.values }
-              .from([active_record_1,active_record_2,data_mapper_1])
-              .to([active_record_1,active_record_2])
-          end
-        end
 
         context "with differing strategies" do
           let(:active_record_1) { FakeStrategy.new(:active_record, :default, :truncation) }


### PR DESCRIPTION
With the decomposition of this gem into individual ORM adapter gems, users of this library are now explicitly opting in to which ORMs they are using by virtue of which adapter gems they require. That -- plus the fact that ORM autodetection has been removed -- makes the `#orm=` setter methods at the various levels of the DC object graph rather useless at best, and problematic at worst, IMO. Lastly, note that there's no diff in the README, because this method was never advertised in it (AFAICT with git log -p), so that helps things a bit.

Still, it is a breaking change, and while we are gearing up for a breaking release with v2.0.0, this method has not been deprecated in the v1.x series.

Assuming that we do indeed want to follow through with this API removal, I can think of three paths forward:
1. Do nothing. Simply release v2.0.0 without the #orm= methods.
2. Push a deprecation warning into a v1.8.x release.
3. Hold off on a new v1.8.x release, but push a deprecation warning into a new branch for a v1.9 release that will contain this deprecation, and any other we might discover we want to do before v2.0.

@etagwerker @JonRowe What do you guys think about all this? Any reason we might not want to remove this? Other considerations or ideas?