### PR TITLE
Fix :mongo strategy

### DIFF
--- a/adapters/database_cleaner-mongo/lib/database_cleaner/mongo/truncation.rb
+++ b/adapters/database_cleaner-mongo/lib/database_cleaner/mongo/truncation.rb
@@ -1,9 +1,11 @@
 require 'database_cleaner/mongo/base'
+require 'database_cleaner/generic/base'
 require 'database_cleaner/generic/truncation'
 require 'database_cleaner/mongo/truncation_mixin'
 module DatabaseCleaner
   module Mongo
     class Truncation
+      include ::DatabaseCleaner::Generic::Base
       include ::DatabaseCleaner::Generic::Truncation
       include TruncationMixin
       include Base

--- a/lib/database_cleaner/orm_autodetector.rb
+++ b/lib/database_cleaner/orm_autodetector.rb
@@ -5,6 +5,7 @@ module DatabaseCleaner
       data_mapper: "DataMapper",
       mongo_mapper: "MongoMapper",
       mongoid: "Mongoid",
+      mongo: "Mongo",
       couch_potato: "CouchPotato",
       sequel: "Sequel",
       moped: "Moped",

--- a/spec/database_cleaner/base_spec.rb
+++ b/spec/database_cleaner/base_spec.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require 'data_mapper'
+require 'mongo'
 require 'mongo_mapper'
 require 'mongoid'
 require 'couch_potato'
@@ -18,6 +19,7 @@ module DatabaseCleaner
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        hide_const "Mongo"
         hide_const "CouchPotato"
         hide_const "Sequel"
         hide_const "Moped"
@@ -26,7 +28,7 @@ module DatabaseCleaner
         hide_const "Neo4j"
 
         expect { subject }.to raise_error(DatabaseCleaner::NoORMDetected, <<-ERROR.chomp)
-No known ORM was detected!  Is ActiveRecord, DataMapper, MongoMapper, Mongoid, CouchPotato, Sequel, Moped, Ohm, Redis, or Neo4j loaded?
+No known ORM was detected!  Is ActiveRecord, DataMapper, MongoMapper, Mongoid, Mongo, CouchPotato, Sequel, Moped, Ohm, Redis, or Neo4j loaded?
         ERROR
       end
 
@@ -56,41 +58,54 @@ No known ORM was detected!  Is ActiveRecord, DataMapper, MongoMapper, Mongoid, C
         expect(subject).to be_auto_detected
       end
 
-      it "should detect CouchPotato fifth" do
+      it "should detect Mongo fifth" do
         hide_const "ActiveRecord"
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        expect(subject.orm).to eq :mongo
+        expect(subject).to be_auto_detected
+      end
+
+      it "should detect CouchPotato sixth" do
+        hide_const "ActiveRecord"
+        hide_const "DataMapper"
+        hide_const "MongoMapper"
+        hide_const "Mongoid"
+        hide_const "Mongo"
         expect(subject.orm).to eq :couch_potato
         expect(subject).to be_auto_detected
       end
 
-      it "should detect Sequel sixth" do
+      it "should detect Sequel seventh" do
         hide_const "ActiveRecord"
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        hide_const "Mongo"
         hide_const "CouchPotato"
         expect(subject.orm).to eq :sequel
         expect(subject).to be_auto_detected
       end
 
-      it 'detects Moped seventh' do
+      it 'detects Moped eighth' do
         hide_const "ActiveRecord"
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        hide_const "Mongo"
         hide_const "CouchPotato"
         hide_const "Sequel"
         expect(subject.orm).to eq :moped
         expect(subject).to be_auto_detected
       end
 
-      it 'detects Ohm eighth' do
+      it 'detects Ohm ninth' do
         hide_const "ActiveRecord"
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        hide_const "Mongo"
         hide_const "CouchPotato"
         hide_const "Sequel"
         hide_const "Moped"
@@ -98,11 +113,12 @@ No known ORM was detected!  Is ActiveRecord, DataMapper, MongoMapper, Mongoid, C
         expect(subject).to be_auto_detected
       end
 
-      it 'detects Redis ninth' do
+      it 'detects Redis tenth' do
         hide_const "ActiveRecord"
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        hide_const "Mongo"
         hide_const "CouchPotato"
         hide_const "Sequel"
         hide_const "Moped"
@@ -111,11 +127,12 @@ No known ORM was detected!  Is ActiveRecord, DataMapper, MongoMapper, Mongoid, C
         expect(subject).to be_auto_detected
       end
 
-      it 'detects Neo4j tenth' do
+      it 'detects Neo4j eleventh' do
         hide_const "ActiveRecord"
         hide_const "DataMapper"
         hide_const "MongoMapper"
         hide_const "Mongoid"
+        hide_const "Mongo"
         hide_const "CouchPotato"
         hide_const "Sequel"
         hide_const "Moped"

--- a/spec/database_cleaner/configuration_spec.rb
+++ b/spec/database_cleaner/configuration_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe DatabaseCleaner::Configuration do
       expect(subject.cleaners.values).to eq [cleaner]
     end
 
+    it "should accept :mongo" do
+      cleaner = subject[:mongo]
+      expect(cleaner).to be_a(DatabaseCleaner::Base)
+      expect(cleaner.orm).to eq :mongo
+      expect(subject.cleaners.values).to eq [cleaner]
+    end
+
     it "should accept :mongo_mapper" do
       cleaner = subject[:mongo_mapper]
       expect(cleaner).to be_a(DatabaseCleaner::Base)

--- a/spec/database_cleaner/mongo/truncation_spec.rb
+++ b/spec/database_cleaner/mongo/truncation_spec.rb
@@ -19,31 +19,63 @@ RSpec.describe DatabaseCleaner::Mongo::Truncation do
     MongoTest::Gadget.new(name: 'some gadget').save!
   end
 
-  context "by default" do
-    it "truncates all collections" do
-      expect { subject.clean }.to change {
-        [MongoTest::Widget.count, MongoTest::Gadget.count]
-      }.from([1,1]).to([0,0])
+  describe "#clean" do
+    context "by default" do
+      it "truncates all collections" do
+        expect { subject.clean }.to change {
+          [MongoTest::Widget.count, MongoTest::Gadget.count]
+        }.from([1,1]).to([0,0])
+      end
+    end
+
+    context "when collections are provided to the :only option" do
+      subject { described_class.new(only: ['MongoTest::Widget']) }
+
+      it "only truncates the specified collections" do
+        expect { subject.clean }.to change {
+          [MongoTest::Widget.count, MongoTest::Gadget.count]
+        }.from([1,1]).to([0,1])
+      end
+    end
+
+    context "when collections are provided to the :except option" do
+      subject { described_class.new(except: ['MongoTest::Widget']) }
+
+      it "truncates all but the specified collections" do
+        expect { subject.clean }.to change {
+          [MongoTest::Widget.count, MongoTest::Gadget.count]
+        }.from([1,1]).to([1,0])
+      end
     end
   end
 
-  context "when collections are provided to the :only option" do
-    subject { described_class.new(only: ['MongoTest::Widget']) }
-
-    it "only truncates the specified collections" do
-      expect { subject.clean }.to change {
-        [MongoTest::Widget.count, MongoTest::Gadget.count]
-      }.from([1,1]).to([0,1])
+  describe "#cleaning" do
+    context "by default" do
+      it "truncates all collections" do
+        expect { subject.cleaning {} }.to change {
+          [MongoTest::Widget.count, MongoTest::Gadget.count]
+        }.from([1,1]).to([0,0])
+      end
     end
-  end
 
-  context "when collections are provided to the :except option" do
-    subject { described_class.new(except: ['MongoTest::Widget']) }
+    context "when collections are provided to the :only option" do
+      subject { described_class.new(only: ['MongoTest::Widget']) }
 
-    it "truncates all but the specified collections" do
-      expect { subject.clean }.to change {
-        [MongoTest::Widget.count, MongoTest::Gadget.count]
-      }.from([1,1]).to([1,0])
+      it "only truncates the specified collections" do
+        expect { subject.cleaning {} }.to change {
+          [MongoTest::Widget.count, MongoTest::Gadget.count]
+        }.from([1,1]).to([0,1])
+      end
+    end
+
+    context "when collections are provided to the :except option" do
+      subject { described_class.new(except: ['MongoTest::Widget']) }
+
+      it "truncates all but the specified collections" do
+        expect { subject.cleaning {} }.to change {
+          [MongoTest::Widget.count, MongoTest::Gadget.count]
+        }.from([1,1]).to([1,0])
+      end
     end
   end
 end


### PR DESCRIPTION
I send this patch to the maintenance branch because it's broken even on stable release (especially the cause 1 is introduced in 1.8.0).

https://github.com/DatabaseCleaner/database_cleaner/commit/43d6482fb2b7194c554d1f32a0d50b457568f3ac

Please feel free to ask me if I should change the base branch or send the same patch to master branch (and adapter repo) as well.

----

Currently, the following code doesn't work:

```ruby
DatabaseCleaner[:mongo].strategy = :truncation

RSpec.configure do |config|
  config.around do |example|
    DatabaseCleaner.cleaning do
      example.run
    end
  end
end
```

The causes are:

1. `DatabaseCleaner::ORMAutodetector` doesn't consider `:mongo` option
2. `DatabaseCleaner::Mongo::Truncation` doesn't respond to `#cleaning`
