### PR TITLE
Fix :mongo adapter to clean up newly created collection

### DIFF
--- a/adapters/database_cleaner-mongo/lib/database_cleaner/mongo/truncation.rb
+++ b/adapters/database_cleaner-mongo/lib/database_cleaner/mongo/truncation.rb
@@ -15,49 +15,8 @@ module DatabaseCleaner
         db
       end
 
-      def collections_cache
-        @@collections_cache ||= {}
-      end
-
-      def mongoid_collection_names
-        @@mongoid_collection_names ||= Hash.new{|h,k| h[k]=[]}.tap do |names|
-          ObjectSpace.each_object(Class) do |klass|
-            (names[klass.db.name] << klass.collection_name) if valid_collection_name?(klass)
-          end
-        end
-      end
-
-      def not_caching(db_name, list)
-        @@not_caching ||= {}
-
-        unless @@not_caching.has_key?(db_name)
-          @@not_caching[db_name] = true
-
-          puts "Not caching collection names for db #{db_name}. Missing these from models: #{list}"
-        end
-      end
-
       def collections
-        return collections_cache[database.name] if collections_cache.has_key?(database.name)
-        db_collections = database.collections.select { |c| c.name !~ /^system\./ }
-
-        missing_collections = mongoid_collection_names[database.name] - db_collections.map(&:name)
-
-        if missing_collections.empty?
-          collections_cache[database.name] = db_collections
-        else
-          not_caching(database.name, missing_collections)
-        end
-
-        db_collections
-      end
-
-      private
-
-      def valid_collection_name?(klass)
-        klass.ancestors.map(&:to_s).include?('Mongoid::Document') &&
-        !klass.embedded &&
-        !klass.collection_name.empty?
+        database.collections.select { |c| c.name !~ /^system\./ }
       end
     end
   end

--- a/spec/database_cleaner/mongo/mongo_examples.rb
+++ b/spec/database_cleaner/mongo/mongo_examples.rb
@@ -23,4 +23,6 @@ module MongoTest
   end
   class Gadget < Base
   end
+  class Gizmo < Base
+  end
 end

--- a/spec/database_cleaner/mongo/truncation_spec.rb
+++ b/spec/database_cleaner/mongo/truncation_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe DatabaseCleaner::Mongo::Truncation do
       end
     end
 
+    context "when new collection is created after clean" do
+      before do
+        subject.clean
+
+        MongoTest::Gizmo.new(name: 'some gizmo').save!
+      end
+
+      it "truncates new collection" do
+        expect { subject.clean }.to change {
+          MongoTest::Gizmo.count
+        }.from(1).to(0)
+      end
+    end
+
     context "when collections are provided to the :only option" do
       subject { described_class.new(only: ['MongoTest::Widget']) }
 


### PR DESCRIPTION
Currently, :mongo adapter only cleanups collections which exist at the first call of `#clean` because it caches collections.
But both :mongo_mapper and :mongoid adapter doesn't cache.
I confirmed it's slightly faster than non cached one but it costs only 5%.
I think we can accept removing this cache to cleanup all collections.

For some reason, this cache behavior considers mongoid but it doesn't depend on this adapter
so we can just remove these codes.

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'mongo'
  gem 'benchmark-ips', require: 'benchmark/ips'
  gem 'database_cleaner-mongo', '1.8.1'
end

Mongo::Logger.level = Logger::WARN
client = Mongo::Client.new('mongodb://mongo')

strategy1 = DatabaseCleaner::Mongo::Truncation.new.tap {|s| s.db = client.database }
strategy2 = DatabaseCleaner::Mongo::Truncation.new.tap {|s| s.db = client.database }.extend(Module.new do
  def collections
    database.collections.select { |c| c.name !~ /^system\./ }
  end
end)

collection_names = 1000.times.map {|i| "test_#{i}" }
(collection_names - client.collections.map(&:name)).each do |name|
  client[name].create
end

Benchmark.ips do |x|
  x.time = 10

  x.report("with cache") do
    strategy1.clean
  end

  x.report("without cache") do
    strategy2.clean
  end

  x.compare!
end

__END__

$ ruby bench.rb
Warming up --------------------------------------
          with cache     1.000  i/100ms
       without cache     1.000  i/100ms
Calculating -------------------------------------
          with cache      0.835  (± 0.0%) i/s -      9.000  in  10.803207s
       without cache      0.798  (± 0.0%) i/s -      8.000  in  10.034118s

Comparison:
          with cache:        0.8 i/s
       without cache:        0.8 i/s - 1.05x  (± 0.00) slower

```