### PR TITLE
[BREAKING] Rename :connection configuration option to :db for consistency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -294,7 +294,7 @@ For more examples see the section ["Why?"](#why).
 
 Sometimes you need to use multiple ORMs in your application.
 
-You can use DatabaseCleaner to clean multiple ORMs, and multiple connections for those ORMs.
+You can use DatabaseCleaner to clean multiple ORMs, and multiple databases for those ORMs.
 
 ```ruby
 require 'database_cleaner/active_record'
@@ -304,14 +304,14 @@ require 'database_cleaner/mongo_mapper'
 DatabaseCleaner[:active_record].strategy = :transaction
 DatabaseCleaner[:mongo_mapper].strategy = :truncation
 
-# How to specify particular connections
-DatabaseCleaner[:active_record, { :connection => :two }]
+# How to specify particular databases
+DatabaseCleaner[:active_record, { db: :two }]
 
 # You may also pass in the model directly:
-DatabaseCleaner[:active_record, { :model => ModelWithDifferentConnection }]
+DatabaseCleaner[:active_record, { db: ModelWithDifferentConnection }]
 ```
 
-Usage beyond that remains the same with `DatabaseCleaner.start` calling any setup on the different configured connections, and `DatabaseCleaner.clean` executing afterwards.
+Usage beyond that remains the same with `DatabaseCleaner.start` calling any setup on the different configured databases, and `DatabaseCleaner.clean` executing afterwards.
 
 ## Why?
 

--- a/examples/features/step_definitions/activerecord_steps.rb
+++ b/examples/features/step_definitions/activerecord_steps.rb
@@ -2,8 +2,8 @@ Given /^I have setup database cleaner to clean multiple databases using activere
   #DatabaseCleaner
   # require "#{File.dirname(__FILE__)}/../../../lib/datamapper_models"
   #
-  # DatabaseCleaner[:active_record, connection: :one].strategy = :truncation
-  # DatabaseCleaner[:active_record, connection: :two].strategy = :truncation
+  # DatabaseCleaner[:active_record, db: :one].strategy = :truncation
+  # DatabaseCleaner[:active_record, db: :two].strategy = :truncation
 end
 
 When /^I create a widget using activerecord$/ do

--- a/examples/features/step_definitions/redis_steps.rb
+++ b/examples/features/step_definitions/redis_steps.rb
@@ -2,8 +2,8 @@ Given /^I have setup database cleaner to clean multiple databases using redis$/ 
   #DatabaseCleaner
   # require "#{File.dirname(__FILE__)}/../../../lib/redis_models"
   #
-  # DatabaseCleaner[:redis, {:connection => ENV['REDIS_URL_ONE']} ].strategy = :truncation
-  # DatabaseCleaner[:redis, {:connection => ENV['REDIS_URL_TWO']} ].strategy = :truncation
+  # DatabaseCleaner[:redis, db: ENV['REDIS_URL_ONE']].strategy = :truncation
+  # DatabaseCleaner[:redis, db: ENV['REDIS_URL_TWO']].strategy = :truncation
 end
 
 When /^I create a widget using redis$/ do

--- a/examples/features/support/env.rb
+++ b/examples/features/support/env.rb
@@ -47,11 +47,11 @@ if orm && strategy
 
     case orm_sym
     when :redis
-      DatabaseCleaner[orm_sym, connection: ENV['REDIS_URL_ONE']].strategy = strategy.to_sym
-      DatabaseCleaner[orm_sym, connection: ENV['REDIS_URL_TWO']].strategy = strategy.to_sym
+      DatabaseCleaner[orm_sym, db: ENV['REDIS_URL_ONE']].strategy = strategy.to_sym
+      DatabaseCleaner[orm_sym, db: ENV['REDIS_URL_TWO']].strategy = strategy.to_sym
     when :active_record
-      DatabaseCleaner[:active_record, model: ActiveRecordWidgetUsingDatabaseOne].strategy = strategy.to_sym
-      DatabaseCleaner[:active_record, model: ActiveRecordWidgetUsingDatabaseTwo].strategy = strategy.to_sym
+      DatabaseCleaner[:active_record, db: ActiveRecordWidgetUsingDatabaseOne].strategy = strategy.to_sym
+      DatabaseCleaner[:active_record, db: ActiveRecordWidgetUsingDatabaseTwo].strategy = strategy.to_sym
     end
 
   elsif another_orm

--- a/lib/database_cleaner/cleaner.rb
+++ b/lib/database_cleaner/cleaner.rb
@@ -25,9 +25,9 @@ module DatabaseCleaner
       [orm, db] <=> [other.orm, other.db]
     end
 
-    def initialize(orm, opts = {})
+    def initialize(orm, db: nil)
       @orm = orm
-      self.db = opts[:connection] || opts[:model] if opts.has_key?(:connection) || opts.has_key?(:model)
+      self.db = db
       Safeguard.new.run
     end
 

--- a/lib/database_cleaner/cleaners.rb
+++ b/lib/database_cleaner/cleaners.rb
@@ -18,21 +18,21 @@ module DatabaseCleaner
     end
 
     def start
-      values.each { |connection| connection.start }
+      values.each { |cleaner| cleaner.start }
     end
 
     def clean
-      values.each { |connection| connection.clean }
+      values.each { |cleaner| cleaner.clean }
     end
 
     def cleaning(&inner_block)
-      values.inject(inner_block) do |curr_block, connection|
-        proc { connection.cleaning(&curr_block) }
+      values.inject(inner_block) do |curr_block, cleaner|
+        proc { cleaner.cleaning(&curr_block) }
       end.call
     end
 
     def clean_with(*args)
-      values.each { |connection| connection.clean_with(*args) }
+      values.each { |cleaner| cleaner.clean_with(*args) }
     end
 
     private

--- a/lib/database_cleaner/null_strategy.rb
+++ b/lib/database_cleaner/null_strategy.rb
@@ -4,7 +4,7 @@ module DatabaseCleaner
       # no-op
     end
     
-    def db=(connection)
+    def db=(db)
       # no-op
     end
      

--- a/spec/database_cleaner/cleaner_spec.rb
+++ b/spec/database_cleaner/cleaner_spec.rb
@@ -1,25 +1,25 @@
 module DatabaseCleaner
   RSpec.describe Cleaner do
     describe "comparison" do
-      it "should be equal if orm and connection are the same" do
-        one = Cleaner.new(:active_record, connection: :default)
-        two = Cleaner.new(:active_record, connection: :default)
+      it "should be equal if orm and db are the same" do
+        one = Cleaner.new(:active_record, db: :default)
+        two = Cleaner.new(:active_record, db: :default)
 
         expect(one).to eq two
         expect(two).to eq one
       end
 
       it "should not be equal if orm are not the same" do
-        one = Cleaner.new(:mongo_id, connection: :default)
-        two = Cleaner.new(:active_record, connection: :default)
+        one = Cleaner.new(:mongo_id, db: :default)
+        two = Cleaner.new(:active_record, db: :default)
 
         expect(one).not_to eq two
         expect(two).not_to eq one
       end
 
-      it "should not be equal if connection are not the same" do
-        one = Cleaner.new(:active_record, connection: :default)
-        two = Cleaner.new(:active_record, connection: :other)
+      it "should not be equal if db are not the same" do
+        one = Cleaner.new(:active_record, db: :default)
+        two = Cleaner.new(:active_record, db: :other)
 
         expect(one).not_to eq two
         expect(two).not_to eq one
@@ -28,9 +28,9 @@ module DatabaseCleaner
 
     describe "initialization" do
       context "db specified" do
-        subject(:cleaner) { Cleaner.new(:active_record, connection: :my_db) }
+        subject(:cleaner) { Cleaner.new(:active_record, db: :my_db) }
 
-        it "should store db from :connection in params hash" do
+        it "should store db from :db in params hash" do
           expect(cleaner.db).to eq :my_db
         end
       end

--- a/spec/database_cleaner/cleaners_spec.rb
+++ b/spec/database_cleaner/cleaners_spec.rb
@@ -19,25 +19,25 @@ RSpec.describe DatabaseCleaner::Cleaners do
       expect(cleaners.values).to eq cleaners_values
     end
 
-    it "should accept a connection parameter and store it" do
-      cleaner = cleaners[:active_record, connection: :first_connection]
+    it "should accept a db parameter and store it" do
+      cleaner = cleaners[:active_record, db: :first_db]
       expect(cleaner).to be_a(DatabaseCleaner::Cleaner)
       expect(cleaner.orm).to eq :active_record
-      expect(cleaner.db).to eq :first_connection
+      expect(cleaner.db).to eq :first_db
     end
 
-    it "should accept multiple connections for a single orm" do
-      cleaners[:data_mapper, connection: :first_db]
-      cleaners[:data_mapper, connection: :second_db]
+    it "should accept multiple dbs for a single orm" do
+      cleaners[:data_mapper, db: :first_db]
+      cleaners[:data_mapper, db: :second_db]
       expect(cleaners.values.map(&:orm)).to eq [:data_mapper, :data_mapper]
       expect(cleaners.values.map(&:db)).to eq [:first_db, :second_db]
     end
 
-    it "should accept multiple connections and multiple orms" do
-      cleaners[:data_mapper,   connection: :first_db ]
-      cleaners[:active_record, connection: :second_db]
-      cleaners[:active_record, connection: :first_db ]
-      cleaners[:data_mapper,   connection: :second_db]
+    it "should accept multiple dbs and multiple orms" do
+      cleaners[:data_mapper,   db: :first_db ]
+      cleaners[:active_record, db: :second_db]
+      cleaners[:active_record, db: :first_db ]
+      cleaners[:data_mapper,   db: :second_db]
       expect(cleaners.values.map(&:orm)).to eq [:data_mapper, :active_record, :active_record, :data_mapper]
       expect(cleaners.values.map(&:db)).to eq [:first_db, :second_db, :first_db, :second_db]
     end
@@ -54,7 +54,7 @@ RSpec.describe DatabaseCleaner::Cleaners do
   end
 
   context "top level api methods" do
-    context "single orm single connection" do
+    context "single orm single db" do
       let(:cleaner) { cleaners[:active_record] }
 
       it "should proxy strategy=" do
@@ -121,9 +121,9 @@ RSpec.describe DatabaseCleaner::Cleaners do
           cleaners.clean_with stratagem
         end
 
-        it "should initiate cleaning on each connection, yield, and finish cleaning each connection" do
-          [active_record, data_mapper].each do |connection|
-            class << connection
+        it "should initiate cleaning on each db, yield, and finish cleaning each db" do
+          [active_record, data_mapper].each do |db|
+            class << db
               attr_reader :started, :cleaned
 
               def cleaning &block


### PR DESCRIPTION
Renames the `:model` option, too, which was simply an alias, and shouldn't be in core, anyways, since it was ActiveRecord-specific. Will deprecate that one, too, in v1.99.

Closes #649

With this PR, and the truncation -> deletion renaming PRs in a few of the adapters, I think v2.0 is feature-complete!! I'm hoping to release both v1.99.0.beta and v2.0.0.beta versions of everything this weekend.

Its happening!!