### PR TITLE
[v1.99] Deprecate :connection and :model in favor of :db 

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -3,12 +3,14 @@
 == Changes
   * Remove unnecessary dependency on database_cleaner-mongo from database_cleaner-mongoid: @botandrose
   * Enable the :cache_tables option for the mongo truncation strategy, and default to true: https://github.com/DatabaseCleaner/database_cleaner/pull/646"
+  * Add new :db orm configuration key, for consistency with #db and #db=. https://github.com/DatabaseCleaner/database_cleaner/pull/649
 
 == Deprecations
   * Deprecate all #orm= setter methods: https://github.com/DatabaseCleaner/database_cleaner/pull/643
   * Deprecate non-functional :reset_ids option in ActiveRecord truncation strategy: https://github.com/DatabaseCleaner/database_cleaner/issues/559
   * Deprecate mongo truncation's `:cache_tables => true` option in favor of `false`, to prep for caching removal in v2.0: https://github.com/DatabaseCleaner/database_cleaner/pull/646"
   * Deprecate redis truncation's #url method in favor of #db: @botandrose
+  * Deprecate :connection and :model configuration options in favor of :db for consistency: https://github.com/DatabaseCleaner/database_cleaner/pull/650
 
 == Bugfixes
 

--- a/README.markdown
+++ b/README.markdown
@@ -306,10 +306,10 @@ DatabaseCleaner[:active_record].strategy = :transaction
 DatabaseCleaner[:mongo_mapper].strategy = :truncation
 
 # How to specify particular connections
-DatabaseCleaner[:active_record, { :connection => :two }]
+DatabaseCleaner[:active_record, { :db => :two }]
 
 # You may also pass in the model directly:
-DatabaseCleaner[:active_record, { :model => ModelWithDifferentConnection }]
+DatabaseCleaner[:active_record, { :db => ModelWithDifferentConnection }]
 ```
 
 Usage beyond that remains the same with `DatabaseCleaner.start` calling any setup on the different configured connections, and `DatabaseCleaner.clean` executing afterwards.

--- a/adapters/database_cleaner-mongoid/README.md
+++ b/adapters/database_cleaner-mongoid/README.md
@@ -47,7 +47,7 @@ end
     <tr>
       <td> Mongoid</td>
       <td> <code>DatabaseCleaner[:mongoid]</code></td>
-      <td> Multiple databases supported for Mongoid 3. Specify <code>DatabaseCleaner[:mongoid, {:connection =&gt; :db_name}]</code> </td>
+      <td> Multiple databases supported for Mongoid 3. Specify <code>DatabaseCleaner[:mongoid, {:db =&gt; :db_name}]</code> </td>
     </tr>
   </tbody>
 </table>

--- a/adapters/database_cleaner-neo4j/README.md
+++ b/adapters/database_cleaner-neo4j/README.md
@@ -47,7 +47,7 @@ end
     <tr>
       <td>Neo4j</td>
       <td><code>DatabaseCleaner[:neo4j]</code></td>
-      <td>Database type and path(URI) <code>DatabaseCleaner[:neo4j, connection: {type: :server_db, path: 'http://localhost:7475'}].</code></td>
+      <td>Database type and path(URI) <code>DatabaseCleaner[:neo4j, db: {type: :server_db, path: 'http://localhost:7475'}].</code></td>
     </tr>
   </tbody>
 </table>

--- a/adapters/database_cleaner-sequel/README.md
+++ b/adapters/database_cleaner-sequel/README.md
@@ -49,7 +49,7 @@ Here is an overview of the supported strategies:
     <tr>
       <td> Sequel</td>
       <td> <code>DatabaseCleaner[:sequel]</code></td>
-      <td> Multiple databases supported; specify <code>DatabaseCleaner[:sequel, {:connection =&gt; Sequel.connect(uri)}]</code></td>
+      <td> Multiple databases supported; specify <code>DatabaseCleaner[:sequel, {:db =&gt; Sequel.connect(uri)}]</code></td>
     </tr>
   </tbody>
 </table>

--- a/lib/database_cleaner/base.rb
+++ b/lib/database_cleaner/base.rb
@@ -15,7 +15,13 @@ module DatabaseCleaner
     def initialize(desired_orm = nil, opts = {})
       @orm_autodetector = ORMAutodetector.new
       self.orm = desired_orm
-      self.db = opts[:connection] || opts[:model] if opts.has_key?(:connection) || opts.has_key?(:model)
+      if opts.has_key?(:model)
+        DatabaseCleaner.deprecate "Using the `:model` key in `DatabaseCleaner[:orm, model: ...]` is deprecated, and will be removed in database_cleaner 2.0. Please use the new `:db` key, instead, which has identical behavior: `DatabaseCleaner[:orm, db: ...]`."
+      end
+      if opts.has_key?(:connection)
+        DatabaseCleaner.deprecate "Using the `:connection` key in `DatabaseCleaner[:orm, connection: ...]` is deprecated, and will be removed in database_cleaner 2.0. Please use the new `:db` key, instead, which has identical behavior: `DatabaseCleaner[:orm, db: ...]`."
+      end
+      self.db = opts[:db] || opts[:connection] || opts[:model] if opts.has_key?(:db) || opts.has_key?(:connection) || opts.has_key?(:model)
       self.strategy = orm_module && orm_module.default_strategy
       Safeguard.new.run
     end


### PR DESCRIPTION
v1.99 deprecation companion PR for https://github.com/DatabaseCleaner/database_cleaner/pull/650