### PR TITLE
Fix deprecation warning about `DatabaseCleaner.connections`

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -11,6 +11,7 @@
   * Deprecate redis truncation's #url method in favor of #db: @botandrose
 
 == Bugfixes
+  * Fix deprecation warning about `DatabaseCleaner.connections` to recommend a better alternative: https://github.com/DatabaseCleaner/database_cleaner/pull/656
 
 == 1.8.5 2020-05-04
 

--- a/lib/database_cleaner/configuration.rb
+++ b/lib/database_cleaner/configuration.rb
@@ -111,7 +111,7 @@ module DatabaseCleaner
 
     def connections
       if DatabaseCleaner.called_externally?(__FILE__, caller)
-        DatabaseCleaner.deprecate "Calling `DatabaseCleaner.connections` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.cleaners`, instead."
+        DatabaseCleaner.deprecate "Calling `DatabaseCleaner.connections` is deprecated, and will be removed in database_cleaner 2.0. Use `DatabaseCleaner.cleaners.values`, instead."
       end
       add_cleaner(:autodetect) if @cleaners.none?
       @cleaners.values


### PR DESCRIPTION
Closes https://github.com/DatabaseCleaner/database_cleaner/issues/655.