### PR TITLE
Add more descriptive "allowlist" terminology

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,11 @@
+== Development (unreleased)
+
+=== Changes
+  * Rename `url_whitelist` to `url_allowlist`
+
+=== Breaking changes
+  * Failed checks against the allowlist now raise `UrlNotAllowed` rather than `NotWhitelistedUrl`
+
 == 2.0.0.beta2 2020-05-30
 
 === Features

--- a/README.markdown
+++ b/README.markdown
@@ -342,11 +342,11 @@ DatabaseCleaner.allow_production = true
 DatabaseCleaner.allow_remote_database_url = true
 ```
 
-In Ruby, a URL whitelist can be specified. When specified, DatabaseCleaner will only allow `DATABASE_URL` to be equal
-to one of the values specified in the url whitelist like so:
+In Ruby, a URL allowlist can be specified. When specified, DatabaseCleaner will only allow `DATABASE_URL` to be equal
+to one of the values specified in the url allowlist like so:
 
 ```ruby
-DatabaseCleaner.url_whitelist = ['postgres://postgres@localhost', 'postgres://foo@bar']
+DatabaseCleaner.url_allowlist = ['postgres://postgres@localhost', 'postgres://foo@bar']
 ```
 
 ## COPYRIGHT

--- a/lib/database_cleaner/core.rb
+++ b/lib/database_cleaner/core.rb
@@ -14,7 +14,10 @@ module DatabaseCleaner
       :cleaning,
     ] => :cleaners
 
-    attr_accessor :allow_remote_database_url, :allow_production, :url_whitelist
+    attr_accessor :allow_remote_database_url, :allow_production, :url_allowlist
+
+    alias :url_whitelist :url_allowlist
+    alias :url_whitelist= :url_allowlist=
 
     def cleaners
       @cleaners ||= Cleaners.new

--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -13,27 +13,27 @@ module DatabaseCleaner
         end
       end
 
-      class NotWhitelistedUrl < Error
+      class UrlNotAllowed < Error
         def initialize
-          super("ENV['DATABASE_URL'] is set to a URL that is not on the whitelist. Please refer to https://github.com/DatabaseCleaner/database_cleaner#safeguards")
+          super("ENV['DATABASE_URL'] is set to a URL that is not on the allowlist. Please refer to https://github.com/DatabaseCleaner/database_cleaner#safeguards")
         end
       end
     end
 
-    class WhitelistedUrl
+    class AllowedUrl
       def run
         return if skip?
-        raise Error::NotWhitelistedUrl if database_url_not_whitelisted?
+        raise Error::UrlNotAllowed if database_url_not_allowed?
       end
 
       private
 
-        def database_url_not_whitelisted?
-          !DatabaseCleaner.url_whitelist.include?(ENV['DATABASE_URL'])
+        def database_url_not_allowed?
+          !DatabaseCleaner.url_allowlist.include?(ENV['DATABASE_URL'])
         end
 
         def skip?
-          !DatabaseCleaner.url_whitelist
+          !DatabaseCleaner.url_allowlist
         end
     end
 
@@ -67,7 +67,7 @@ module DatabaseCleaner
         def skip?
           ENV['DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL'] ||
             DatabaseCleaner.allow_remote_database_url ||
-            DatabaseCleaner.url_whitelist
+            DatabaseCleaner.url_allowlist
         end
     end
 
@@ -97,7 +97,7 @@ module DatabaseCleaner
     CHECKS = [
       RemoteDatabaseUrl,
       Production,
-      WhitelistedUrl
+      AllowedUrl
     ]
 
     def run

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -72,43 +72,56 @@ module DatabaseCleaner
         end
       end
 
-      describe 'DatabaseCleaner.url_whitelist is set' do
-        let(:url_whitelist) { ['postgres://postgres@localhost', 'postgres://foo.bar'] }
+      describe 'DatabaseCleaner.url_allowlist is set' do
 
-        before { DatabaseCleaner.url_whitelist = url_whitelist }
-        after  { DatabaseCleaner.url_whitelist = nil }
+        shared_examples 'allowlist assigned' do
+          describe 'A remote url is on the allowlist' do
+            let(:database_url) { 'postgres://foo.bar' }
 
-        describe 'A remote url is on the whitelist' do
-          let(:database_url) { 'postgres://foo.bar' }
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
+          end
 
-          it 'does not raise' do
-            expect { cleaner.start }.to_not raise_error
+          describe 'A remote url is not on the allowlist' do
+            let(:database_url) { 'postgress://bar.baz' }
+
+            it 'raises a allowlist error' do
+              expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
+            end
+          end
+
+          describe 'A local url is on the allowlist' do
+            let(:database_url) { 'postgres://postgres@localhost' }
+
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
+          end
+
+          describe 'A local url is not on the allowlist' do
+            let(:database_url) { 'postgres://localhost' }
+
+            it 'raises a not allowed error' do
+              expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
+            end
           end
         end
 
-        describe 'A remote url is not on the whitelist' do
-          let(:database_url) { 'postgress://bar.baz' }
+        let(:url_allowlist) { ['postgres://postgres@localhost', 'postgres://foo.bar'] }
 
-          it 'raises a whitelist error' do
-            expect { cleaner.start }.to raise_error(Safeguard::Error::NotWhitelistedUrl)
-          end
+        describe 'url_allowlist' do
+          before { DatabaseCleaner.url_allowlist = url_allowlist }
+          after  { DatabaseCleaner.url_allowlist = nil }
+          it_behaves_like 'allowlist assigned'
         end
 
-        describe 'A local url is on the whitelist' do
-          let(:database_url) { 'postgres://postgres@localhost' }
-
-          it 'does not raise' do
-            expect { cleaner.start }.to_not raise_error
-          end
+        describe 'url_whitelist' do
+          before { DatabaseCleaner.url_whitelist = url_allowlist }
+          after  { DatabaseCleaner.url_whitelist = nil }
+          it_behaves_like 'allowlist assigned'
         end
 
-        describe 'A local url is not on the whitelist' do
-          let(:database_url) { 'postgres://localhost' }
-
-          it 'raises a whitelist error' do
-            expect { cleaner.start }.to raise_error(Safeguard::Error::NotWhitelistedUrl)
-          end
-        end
       end
     end
 


### PR DESCRIPTION
Hi there, thanks for maintaining DatabaseCleaner!

This runs `s/url_whitelist/url_allowlist/` and adds backwards-compatible
aliases for the terminology which can be easily deprecated or dropped
in the future, should that be desired.

This also replaces the error `NotWhitelistedUrl` with the more descriptive
`UrlNotAllowed`. I believe merging will resolve #626.