### PR TITLE
Support regular expressions in allowlist

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -2,6 +2,7 @@
 
 === Changes
   * Rename `url_whitelist` to `url_allowlist`
+  * Allowlist now supports regular expressions
 
 === Breaking changes
   * Failed checks against the allowlist now raise `UrlNotAllowed` rather than `NotWhitelistedUrl`

--- a/README.markdown
+++ b/README.markdown
@@ -349,6 +349,12 @@ to one of the values specified in the url allowlist like so:
 DatabaseCleaner.url_allowlist = ['postgres://postgres@localhost', 'postgres://foo@bar']
 ```
 
+Allowlist elements may be specified as regular expressions if extra flexibility is required::
+
+```ruby
+DatabaseCleaner.url_allowlist = [%r{^postgres://postgres@localhost}]
+```
+
 ## COPYRIGHT
 
 See [LICENSE](LICENSE) for details.

--- a/README.markdown
+++ b/README.markdown
@@ -349,10 +349,13 @@ to one of the values specified in the url allowlist like so:
 DatabaseCleaner.url_allowlist = ['postgres://postgres@localhost', 'postgres://foo@bar']
 ```
 
-Allowlist elements may be specified as regular expressions if extra flexibility is required::
+Allowlist elements are matched with case equality (`===`), so regular expressions or procs may be used:
 
 ```ruby
-DatabaseCleaner.url_allowlist = [%r{^postgres://postgres@localhost}]
+DatabaseCleaner.url_allowlist = [
+  %r{^postgres://postgres@localhost},         # match any db with this prefix
+  proc {|uri| URI.parse(uri).user == "test" } # match any db authenticating with the 'test' user
+]
 ```
 
 ## COPYRIGHT

--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -29,7 +29,7 @@ module DatabaseCleaner
       private
 
         def database_url_not_allowed?
-          !DatabaseCleaner.url_allowlist.include?(ENV['DATABASE_URL'])
+          !DatabaseCleaner.url_allowlist.any? {|allowed| allowed === ENV['DATABASE_URL'] }
         end
 
         def skip?

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -86,7 +86,7 @@ module DatabaseCleaner
           describe 'A remote url is not on the allowlist' do
             let(:database_url) { 'postgress://bar.baz' }
 
-            it 'raises a allowlist error' do
+            it 'raises a not allowed error' do
               expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
             end
           end
@@ -94,7 +94,7 @@ module DatabaseCleaner
           describe 'A similar url not explicitly matched as a pattern' do
             let(:database_url) { 'postgres://foo.bar?pool=8' }
 
-            it 'raises an allowlist error' do
+            it 'raises a not allowed error' do
               expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
             end
           end

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -91,6 +91,22 @@ module DatabaseCleaner
             end
           end
 
+          describe 'A similar url not explicitly matched as a pattern' do
+            let(:database_url) { 'postgres://foo.bar?pool=8' }
+
+            it 'raises an allowlist error' do
+              expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
+            end
+          end
+
+          describe 'A remote url matches a pattern on the allowlist' do
+            let(:database_url) { 'postgres://bar.baz?pool=16' }
+
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
+          end
+
           describe 'A local url is on the allowlist' do
             let(:database_url) { 'postgres://postgres@localhost' }
 
@@ -108,7 +124,7 @@ module DatabaseCleaner
           end
         end
 
-        let(:url_allowlist) { ['postgres://postgres@localhost', 'postgres://foo.bar'] }
+        let(:url_allowlist) { ['postgres://postgres@localhost', 'postgres://foo.bar', %r{^postgres://bar.baz}] }
 
         describe 'url_allowlist' do
           before { DatabaseCleaner.url_allowlist = url_allowlist }

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -122,9 +122,24 @@ module DatabaseCleaner
               expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
             end
           end
+
+          describe 'A url that matches a proc' do
+            let(:database_url) { 'redis://test:test@foo.bar' }
+
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
+          end
         end
 
-        let(:url_allowlist) { ['postgres://postgres@localhost', 'postgres://foo.bar', %r{^postgres://bar.baz}] }
+        let(:url_allowlist) do
+          [
+            'postgres://postgres@localhost',
+            'postgres://foo.bar',
+            %r{^postgres://bar.baz},
+            proc { |x| URI.parse(x).user == 'test' }
+          ]
+        end
 
         describe 'url_allowlist' do
           before { DatabaseCleaner.url_allowlist = url_allowlist }


### PR DESCRIPTION
It's common for database connection parameters to be specified as part of the URL (e.g. `DATABASE_URL=postgres://foo.bar?pool=16`). I'd like to be able to manipulate those connection parameters in my test rig without needing to alter the allowlist.

This patch supports this by letting allowlists optionally be specified as regular expressions.