### PR TITLE
Add APP_ENV

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -323,7 +323,7 @@ After copying and pasting code to do this several times I decided to package it 
 
 DatabaseCleaner comes with safeguards against:
 
-* Running in production (checking for `ENV`, `RACK_ENV`, and `RAILS_ENV`)
+* Running in production (checking for `ENV`, `APP_ENV`, `RACK_ENV`, and `RAILS_ENV`)
 * Running against a remote database (checking for a `DATABASE_URL` that does not include `localhost`, `.local` or `127.0.0.1`)
 
 Both safeguards can be disabled separately as follows.

--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -72,7 +72,7 @@ module DatabaseCleaner
     end
 
     class Production
-      KEYS = %w(ENV RACK_ENV RAILS_ENV)
+      KEYS = %w(ENV APP_ENV RACK_ENV RAILS_ENV)
 
       def run
         raise Error::ProductionEnv.new(key) if !skip? && given?

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -126,7 +126,7 @@ module DatabaseCleaner
     end
 
     describe 'ENV is set to production' do
-      %w(ENV RACK_ENV RAILS_ENV).each do |key|
+      %w(ENV APP_ENV RACK_ENV RAILS_ENV).each do |key|
         describe "on #{key}" do
           before { stub_const('ENV', key => "production") }
 


### PR DESCRIPTION
`APP_ENV` is becoming the "preferred" environment variable in various frameworks and scenarios as a more generic way of specifying an environment that may optionally diverge from the typical `development` and `production` names.

Some examples of adopting `APP_ENV`:
- Sidekiq: https://github.com/mperham/sidekiq/commit/95fa5d90192148026e52ca2902f1b83c70858ce8
- NewRelic: https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration
- AWS: https://github.com/aws/elastic-beanstalk-roadmap/issues/34