### PR TITLE
Remove trailing whitespaces.

### DIFF
--- a/ADAPTERS.md
+++ b/ADAPTERS.md
@@ -26,8 +26,6 @@ You need to add a couple of dependecies to `.gemspec`:
   spec.add_dependency "orm_name", "some version if required"
 ```
 
-#### 
-
 ### File structure
 
 Inside the `lib/database_cleaner/orm_name` directory, you will need to create a few files:

--- a/examples/config/database.yml.example
+++ b/examples/config/database.yml.example
@@ -1,8 +1,8 @@
 #This is an example of what database.yml *should* look like (when I wrote it)
 #The real database.yml is generated automatically by the active record model lib (so it can be correct)
-two: 
+two:
   adapter: sqlite3
   database: /path/to/examples/features/support/../../db/activerecord_two.db
-one: 
+one:
   adapter: sqlite3
   database: /path/to/examples/features/support/../../db/activerecord_one.db

--- a/lib/database_cleaner/cleaners.rb
+++ b/lib/database_cleaner/cleaners.rb
@@ -10,7 +10,7 @@ module DatabaseCleaner
     def [](orm, **opts)
       raise ArgumentError if orm.nil?
       fetch([orm, opts]) { add_cleaner(orm, **opts) }
-    end 
+    end
 
     def strategy=(strategy)
       values.each { |cleaner| cleaner.strategy = strategy }

--- a/lib/database_cleaner/null_strategy.rb
+++ b/lib/database_cleaner/null_strategy.rb
@@ -3,11 +3,11 @@ module DatabaseCleaner
     def start
       # no-op
     end
-    
+
     def db=(db)
       # no-op
     end
-     
+
     def clean
       # no-op
     end


### PR DESCRIPTION
While looking at the changes between 1.8.5 and 2.0.0 I found a trailing whitespace in `lib/database_cleaner/cleaners.rb` and decided to remove it and all other trailing whitespaces I could find.