### PR TITLE
Fixed readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -300,10 +300,10 @@ DatabaseCleaner[:active_record].strategy = :transaction
 DatabaseCleaner[:mongo_mapper].strategy = :truncation
 
 # How to specify particular databases
-DatabaseCleaner[:active_record, { db: :two }]
+DatabaseCleaner[:active_record, db: :two]
 
 # You may also pass in the model directly:
-DatabaseCleaner[:active_record, { db: ModelWithDifferentConnection }]
+DatabaseCleaner[:active_record, db: ModelWithDifferentConnection]
 ```
 
 Usage beyond that remains the same with `DatabaseCleaner.start` calling any setup on the different configured databases, and `DatabaseCleaner.clean` executing afterwards.


### PR DESCRIPTION
if use it as it described in Readme get an exception like
```
ArgumentError:
  wrong number of arguments (given 2, expected 1)
```
on Ruby 3