### PR TITLE
Start testing database_cleaner-core with Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 before_script:
   - bin/setup
 cache:


### PR DESCRIPTION
Hey, 

This PR starts testing the gem with Ruby 3.0. 

Please check it out. 

Thanks! 