### PR TITLE
Fix docs about usage of only and except options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,11 +75,11 @@ DatabaseCleaner.clean
 With the `:truncation` strategy you can also pass in options, for example:
 
 ```ruby
-DatabaseCleaner.strategy = :truncation, only: %w[widgets dogs some_other_table]
+DatabaseCleaner.strategy = [:truncation, only: %w[widgets dogs some_other_table]]
 ```
 
 ```ruby
-DatabaseCleaner.strategy = :truncation, except: %w[widgets]
+DatabaseCleaner.strategy = [:truncation, except: %w[widgets]]
 ```
 
 (I should point out the truncation strategy will never truncate your schema_migrations table.)


### PR DESCRIPTION
The existing docs lead to non-working code at least with Ruby 2.7.

We need to either make the Array or the Hash explicit in order for it to work:

```
irb(main):026:0> DatabaseCleaner[:active_record].strategy = :truncation, only: ["users"]
Traceback (most recent call last):
SyntaxError ((irb):26: syntax error, unexpected tLABEL)
...].strategy = :truncation, only: ["users"]
...                          ^~~~~
irb(main):027:0> DatabaseCleaner[:active_record].strategy = [:truncation, only: ["users"]]
=> [:truncation, {:only=>["users"]}]
irb(main):028:0> DatabaseCleaner[:active_record].strategy = :truncation, {only: ["users"]}
=> [:truncation, {:only=>["users"]}]
```
