### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
@@ -27,7 +28,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -53,12 +53,11 @@ module DatabaseCleaner
 
         def remote?(url)
           return false unless url
-
           parsed = URI.parse(url)
           return false if parsed.scheme == 'sqlite3:'
 
           host = parsed.host
-          return false unless host
+          return false if host.nil? || host.empty?
           return false if LOCAL.include?(host)
           return false if host.end_with? '.local'
           true

--- a/spec/database_cleaner/cleaner_spec.rb
+++ b/spec/database_cleaner/cleaner_spec.rb
@@ -98,7 +98,7 @@ module DatabaseCleaner
       end
 
       it "should pass all arguments to strategy initializer" do
-        expect(strategy_class).to receive(:new).with(:dollar, :amet, ipsum: "random").and_return(strategy)
+        expect(strategy_class).to receive(:new).with(:dollar, :amet, { ipsum: "random" }).and_return(strategy)
         expect(strategy).to receive(:clean)
         cleaner.clean_with :truncation, :dollar, :amet, ipsum: "random"
       end
@@ -145,12 +145,12 @@ module DatabaseCleaner
       end
 
       it "should proxy params with symbolised strategies in an array" do
-        expect(strategy_class).to receive(:new).with(param: "one")
+        expect(strategy_class).to receive(:new).with({ param: "one" })
         cleaner.strategy = [:truncation, param: "one"]
       end
 
       it "should proxy params with symbolised strategies in a separate hash" do
-        expect(strategy_class).to receive(:new).with(param: "one")
+        expect(strategy_class).to receive(:new).with({ param: "one" })
         cleaner.strategy = :truncation, { param: "one" }
       end
 


### PR DESCRIPTION
In addition to adding Ruby 3.2 to the CI matrix, I updated the version of the checkout action.

To get the specs to green I had to make a few additional changes:

1. Add explicit hashes in the `with` clauses to remove ambiguity with keyword arguments
2. Update the safeguard logic to treat an empty string for `host` as local.

This runs green on my fork.