### PR TITLE
Generalize ProductionEnv safeguard error to NonTestEnv.

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,5 +1,8 @@
 == Development (unreleased)
 
+=== Changes
+  * Safeguard against running in non-test environment
+
 == 2.0.2 2023-03-10
 
 == Bugfixes

--- a/README.markdown
+++ b/README.markdown
@@ -318,7 +318,7 @@ After copying and pasting code to do this several times I decided to package it 
 
 DatabaseCleaner comes with safeguards against:
 
-* Running in production (checking for `ENV`, `APP_ENV`, `RACK_ENV`, and `RAILS_ENV`)
+* Running in non-test environment (checking for `ENV`, `APP_ENV`, `RACK_ENV`, and `RAILS_ENV`)
 * Running against a remote database (checking for a `DATABASE_URL` that does not include `localhost`, `.local` or `127.0.0.1`)
 
 Both safeguards can be disabled separately as follows.
@@ -326,14 +326,14 @@ Both safeguards can be disabled separately as follows.
 Using environment variables:
 
 ```
-export DATABASE_CLEANER_ALLOW_PRODUCTION=true
+export DATABASE_CLEANER_ALLOW_NON_TEST_ENV=true
 export DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
 ```
 
 In Ruby:
 
 ```ruby
-DatabaseCleaner.allow_production = true
+DatabaseCleaner.allow_non_test_env = true
 DatabaseCleaner.allow_remote_database_url = true
 ```
 

--- a/lib/database_cleaner/core.rb
+++ b/lib/database_cleaner/core.rb
@@ -15,7 +15,7 @@ module DatabaseCleaner
       :cleaning,
     ] => :cleaners
 
-    attr_accessor :allow_remote_database_url, :allow_production, :url_allowlist
+    attr_accessor :allow_remote_database_url, :allow_non_test_env, :url_allowlist
 
     alias :url_whitelist :url_allowlist
     alias :url_whitelist= :url_allowlist=

--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -7,9 +7,9 @@ module DatabaseCleaner
         end
       end
 
-      class ProductionEnv < Error
+      class NonTestEnv < Error
         def initialize(env)
-          super("ENV['#{env}'] is set to production. Please refer to https://github.com/DatabaseCleaner/database_cleaner#safeguards")
+          super("ENV['#{env}'] is set to non-test environment. Please refer to https://github.com/DatabaseCleaner/database_cleaner#safeguards")
         end
       end
 
@@ -70,11 +70,11 @@ module DatabaseCleaner
         end
     end
 
-    class Production
+    class NonTest
       KEYS = %w(ENV APP_ENV RACK_ENV RAILS_ENV)
 
       def run
-        raise Error::ProductionEnv.new(key) if !skip? && given?
+        raise Error::NonTestEnv.new(key) if !skip? && given?
       end
 
       private
@@ -84,18 +84,18 @@ module DatabaseCleaner
         end
 
         def key
-          @key ||= KEYS.detect { |key| ENV[key] == 'production' }
+          @key ||= KEYS.detect { |key| ENV[key] && ENV[key] != 'test' }
         end
 
         def skip?
-          ENV['DATABASE_CLEANER_ALLOW_PRODUCTION'] ||
-            DatabaseCleaner.allow_production
+          ENV['DATABASE_CLEANER_ALLOW_NON_TEST_ENV'] ||
+            DatabaseCleaner.allow_non_test_env
         end
     end
 
     CHECKS = [
       RemoteDatabaseUrl,
-      Production,
+      NonTest,
       AllowedUrl
     ]
 

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -156,30 +156,32 @@ module DatabaseCleaner
       end
     end
 
-    describe 'ENV is set to production' do
+    describe 'ENV is set to non-test environment' do
       %w(ENV APP_ENV RACK_ENV RAILS_ENV).each do |key|
-        describe "on #{key}" do
-          before { stub_const('ENV', key => "production") }
+        %w(production development foobar).each do |env|
+          describe "on #{key}=#{env}" do
+            before { stub_const('ENV', key => env) }
 
-          it 'raises' do
-            expect { cleaner.start }.to raise_error(Safeguard::Error::ProductionEnv)
+            it 'raises' do
+              expect { cleaner.start }.to raise_error(Safeguard::Error::NonTestEnv)
+            end
           end
-        end
 
-        describe 'DATABASE_CLEANER_ALLOW_PRODUCTION is set' do
-          before { stub_const('ENV', 'DATABASE_CLEANER_ALLOW_PRODUCTION' => true) }
+          describe 'DATABASE_CLEANER_ALLOW_NON_TEST_ENV is set' do
+            before { stub_const('ENV', 'DATABASE_CLEANER_ALLOW_NON_TEST_ENV' => true) }
 
-          it 'does not raise' do
-            expect { cleaner.start }.to_not raise_error
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
           end
-        end
 
-        describe 'DatabaseCleaner.allow_production is true' do
-          before { DatabaseCleaner.allow_production = true }
-          after  { DatabaseCleaner.allow_production = nil }
+          describe 'DatabaseCleaner.allow_non_test_env is true' do
+            before { DatabaseCleaner.allow_non_test_env = true }
+            after  { DatabaseCleaner.allow_non_test_env = nil }
 
-          it 'does not raise' do
-            expect { cleaner.start }.to_not raise_error
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
           end
         end
       end


### PR DESCRIPTION
Expanding on the great idea in https://github.com/DatabaseCleaner/database_cleaner/pull/521, I was surprised to find database cleaner will happily delete data in development database if RAILS_ENV is set to development. This was a problem for us when working with a remote development database through an SSH tunnel. While the existing allow_remote_database_url config could have prevented this, the SSH tunnel being on localhost prevents the existing safeguard from working

So I thought checking the RAILS_ENV would be a good way to prevent this. While it's great that we already prevent doing this in production, there's really no reason to allow deleting data anywhere but test env so generalized this to error on any non-test environment.

I thought about adding a parallel implementation and leaving allow_production in place for existing users but anyone running with that configuration should immediately get an error with this and can then migrate to allow_non_test_env.