### PR TITLE
Update for trilogy

### DIFF
--- a/lib/database_cleaner/spec/database_helper.rb
+++ b/lib/database_cleaner/spec/database_helper.rb
@@ -4,7 +4,7 @@ module DatabaseCleaner
   module Spec
     class DatabaseHelper < Struct.new(:db)
       def self.with_all_dbs &block
-        %w[mysql2 sqlite3 postgres].map(&:to_sym).each do |db|
+        %w[mysql2 sqlite3 postgres trilogy].map(&:to_sym).each do |db|
           yield new(db)
         end
       end
@@ -43,7 +43,7 @@ module DatabaseCleaner
         id_column = case db
           when :sqlite3
             "id INTEGER PRIMARY KEY AUTOINCREMENT"
-          when :mysql2
+          when :mysql2, :trilogy
             "id INTEGER PRIMARY KEY AUTO_INCREMENT"
           when :postgres
             "id SERIAL PRIMARY KEY"

--- a/spec/support/sample.config.yml
+++ b/spec/support/sample.config.yml
@@ -7,6 +7,15 @@ mysql2:
   port: 3306
   encoding: utf8
 
+trilogy:
+  adapter: trilogy
+  database: database_cleaner_test
+  username: root
+  password:
+  host: 127.0.0.1
+  port: 3306
+  encoding: utf8
+
 postgres:
   adapter: postgresql
   database: database_cleaner_test


### PR DESCRIPTION
Propagate trilogy changes back to database_cleaner.

I'm not entirely sure these methods are used by this gem - they seem ActiveRecord specific - but propagating back (with a minor change, since ActiveRecord is not generally present) for consistency.