### PR TITLE
Skip conventional sqlite:// URLs from safeguards

### DIFF
--- a/lib/database_cleaner/safeguard.rb
+++ b/lib/database_cleaner/safeguard.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 module DatabaseCleaner
   class Safeguard
     class Error < Exception
@@ -42,7 +44,8 @@ module DatabaseCleaner
       LOCAL = %w(localhost 127.0.0.1)
 
       def run
-        raise Error::RemoteDatabaseUrl if !skip? && given?
+        return if skip?
+        raise Error::RemoteDatabaseUrl if given?
       end
 
       private
@@ -54,7 +57,7 @@ module DatabaseCleaner
         def remote?(url)
           return false unless url
           parsed = URI.parse(url)
-          return false if parsed.scheme == 'sqlite3:'
+          return false if parsed.scheme == 'sqlite' || parsed.scheme == 'sqlite3'
 
           host = parsed.host
           return false if host.nil? || host.empty?

--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -45,7 +45,23 @@ module DatabaseCleaner
         end
       end
 
-      describe 'to a sqlite db' do
+      describe 'to a sqlite url' do
+        let(:database_url) { 'sqlite://tmp/db.sqlite3' }
+
+        it 'does not raise' do
+          expect { cleaner.start }.to_not raise_error
+        end
+      end
+
+      describe 'to a sqlite3 url' do
+        let(:database_url) { 'sqlite3://tmp/db.sqlite3' }
+
+        it 'does not raise' do
+          expect { cleaner.start }.to_not raise_error
+        end
+      end
+
+      describe 'to a sqlite3 url with no slashes after the scheme' do
         let(:database_url) { 'sqlite3:tmp/db.sqlite3' }
 
         it 'does not raise' do


### PR DESCRIPTION
Update `Safeguard::RemoteDatabaseUrl` to skip URLs like `"sqlite://path/to/file.sqlite"`, which is now the conventional format for URLs to SQLite databases when using libraries like Sequel.

### Context

I'm currently preparing for the release of [Hanami](https://hanamirb.org) v2.2, which includes an integrated database layer for the first time in the 2.x series.

We are defaulting to an SQLite database, and are planning to use Database Cleaner in the test suite we generate for Hanami apps.

However, we were running afoul of your safeguard feature. This is because it considers our default database URL as non-local:

```
sqlite://db/app_name.sqlite
```

With this PR, we update Database Cleaner to permit these files, in keeping with some previous work to permit SQLite database URLs.

### Background

The existing support for skipping SQLite URLs from tripping the Safeguard::RemoteDatabaseUrl check (implemented in #529) only worked for URLs in this exact format (note the missing slahes after the scheme):

```
sqlite3:path/to/file
```

And as `Safeguard::RemoteDatabaseUrl` evolved over time, the special handling of this kind of URL only continued to work incidentally. This early return would never trigger, because the scheme of the above URL is `"sqlite3"`, not `"sqlite3:"` (note, no colon).

```ruby
return false if parsed.scheme == 'sqlite3:'
```

Instead, the the `Safeguard::RemoteDatabaseUrl` would be skipped because further down, this would end up evaluating to true:

```
host = parsed.host
return false if host.nil?
```

For this particular URL string, its URI `host` is indeed nil.

### Changes

The `sqlite3:path/to/file` format of URL is unusual in that it doesn't contain the typical double slashes after the scheme.

In current day usage of Ruby gems like Sequel, these slashes are expected, leading to URLs like this:

```
sqlite://path/to/file.sqlite
```

(This has in fact been Sequel's expected URL format since [at least 2008](https://github.com/jeremyevans/sequel/blob/93987e6b36b1fb5ee0f82342e6a62c5e25070692/doc/CHANGELOG.old#L5501C28-L5501C35))

To permit this, update the faulty scheme checking early return to return for your existing supported `"sqlite3"` URI scheme (sans the colon, so it actually works) as well as the conventional `"sqlite"`.

```ruby
return false if parsed.scheme == 'sqlite' || parsed.scheme == 'sqlite3'
```

Tests are update to match.

### A humble request 😇 

We're planning to release a Hanami 2.2 beta next week, with the full release coming about a month afterwards.

If you find this PR acceptable, I wonder if you might be able to turn around a quick patch release? It doesn't need to be ready for the beta, but if it could be done ~in the next month or so, that would be amazing.

This would allow us to generate Database Cleaner config without any extra ugliness. Currently we have to add the following to the top of our generated config:

```ruby
# Allow Database Cleaner to work on our local sqlite databases
DatabaseCleaner.url_allowlist = [%r{^sqlite://}]
```

Thank you very much! ❤️ 