### PR TITLE
Update main branch references

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/DatabaseCleaner/database_cleaner/actions/workflows/ci.yml/badge.svg)](https://github.com/DatabaseCleaner/database_cleaner/actions/workflows/ci.yml)
 [![Code Climate](https://codeclimate.com/github/DatabaseCleaner/database_cleaner/badges/gpa.svg)](https://codeclimate.com/github/DatabaseCleaner/database_cleaner)
-[![codecov](https://codecov.io/gh/DatabaseCleaner/database_cleaner/branch/master/graph/badge.svg)](https://codecov.io/gh/DatabaseCleaner/database_cleaner)
+[![codecov](https://codecov.io/gh/DatabaseCleaner/database_cleaner/branch/main/graph/badge.svg)](https://codecov.io/gh/DatabaseCleaner/database_cleaner)
 ![Gem Version](https://badge.fury.io/rb/database_cleaner.svg)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=database_cleaner&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=database_cleaner&package-manager=bundler&version-scheme=semver)
 

--- a/database_cleaner.gemspec
+++ b/database_cleaner.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/DatabaseCleaner/database_cleaner"
   spec.license     = "MIT"
 
-  spec.metadata["changelog_uri"] = "https://github.com/DatabaseCleaner/database_cleaner/blob/master/History.rdoc"
+  spec.metadata["changelog_uri"] = "https://github.com/DatabaseCleaner/database_cleaner/blob/main/History.rdoc"
 
   spec.files       = ["lib/database_cleaner.rb"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Updates two references which should use the `main` branch instead of `master`:

* Changelog URL in gemspec
* Coverage badge in readme

Note that the changelog link on rubygems.org will only change with a new gem release.
