### PR TITLE
Ruby 3.4 quoted locations start with single quotes

### DIFF
--- a/lib/database_cleaner/deprecation.rb
+++ b/lib/database_cleaner/deprecation.rb
@@ -1,6 +1,6 @@
 module DatabaseCleaner
   def deprecate message
-    method = caller.first[/\d+:in `(.*)'$/, 1].to_sym
+    method = caller.first[/\d+:in [`'](.*)'$/, 1].to_sym
     @@deprecator ||= Deprecator.new
     @@deprecator.deprecate method, message
   end


### PR DESCRIPTION
As best I can tell, there's been a change to the output of Ruby's stack traces in `caller` - they now start with a 'normal' single quote, instead of a backtick.

This pattern now handles both, to ensure backwards compatibility.