### PR TITLE
Allow Safeguards to be added and/or overridden outside of core

### DIFF
--- a/spec/database_cleaner/safeguard_spec.rb
+++ b/spec/database_cleaner/safeguard_spec.rb
@@ -2,200 +2,241 @@ module DatabaseCleaner
   RSpec.describe Safeguard do
     let(:cleaner)  { Cleaners.new }
 
-    describe 'DATABASE_URL is set' do
-      before { stub_const('ENV', 'DATABASE_URL' => database_url) }
+    describe 'Safeguards defined outside of core' do
+      after { described_class.reset_registry! }
 
-      describe 'to any value' do
-        let(:database_url) { 'postgres://remote.host' }
-
-        it 'raises' do
-          expect { cleaner.start }.to raise_error(Safeguard::Error::RemoteDatabaseUrl)
-        end
-      end
-
-      describe 'to a localhost url' do
-        let(:database_url) { 'postgres://localhost' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'to a local, empty-host url' do
-        let(:database_url) { 'postgres:///' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'to a local tld url' do
-        let(:database_url) { 'postgres://postgres.local' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'to a 127.0.0.1 url' do
-        let(:database_url) { 'postgres://127.0.0.1' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'to a sqlite url' do
-        let(:database_url) { 'sqlite://tmp/db.sqlite3' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'to a sqlite3 url' do
-        let(:database_url) { 'sqlite3://tmp/db.sqlite3' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'to a sqlite3 url with no slashes after the scheme' do
-        let(:database_url) { 'sqlite3:tmp/db.sqlite3' }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL is set' do
-        let(:database_url) { 'postgres://remote.host' }
-        before { stub_const('ENV', 'DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL' => true) }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'DatabaseCleaner.allow_remote_database_url is true' do
-        let(:database_url) { 'postgres://remote.host' }
-        before { DatabaseCleaner.allow_remote_database_url = true }
-        after  { DatabaseCleaner.allow_remote_database_url = nil }
-
-        it 'does not raise' do
-          expect { cleaner.start }.to_not raise_error
-        end
-      end
-
-      describe 'DatabaseCleaner.url_allowlist is set' do
-
-        shared_examples 'allowlist assigned' do
-          describe 'A remote url is on the allowlist' do
-            let(:database_url) { 'postgres://foo.bar' }
-
-            it 'does not raise' do
-              expect { cleaner.start }.to_not raise_error
-            end
-          end
-
-          describe 'A remote url is not on the allowlist' do
-            let(:database_url) { 'postgress://bar.baz' }
-
-            it 'raises a not allowed error' do
-              expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
-            end
-          end
-
-          describe 'A similar url not explicitly matched as a pattern' do
-            let(:database_url) { 'postgres://foo.bar?pool=8' }
-
-            it 'raises a not allowed error' do
-              expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
-            end
-          end
-
-          describe 'A remote url matches a pattern on the allowlist' do
-            let(:database_url) { 'postgres://bar.baz?pool=16' }
-
-            it 'does not raise' do
-              expect { cleaner.start }.to_not raise_error
-            end
-          end
-
-          describe 'A local url is on the allowlist' do
-            let(:database_url) { 'postgres://postgres@localhost' }
-
-            it 'does not raise' do
-              expect { cleaner.start }.to_not raise_error
-            end
-          end
-
-          describe 'A local url is not on the allowlist' do
-            let(:database_url) { 'postgres://localhost' }
-
-            it 'raises a not allowed error' do
-              expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
-            end
-          end
-
-          describe 'A url that matches a proc' do
-            let(:database_url) { 'redis://test:test@foo.bar' }
-
-            it 'does not raise' do
-              expect { cleaner.start }.to_not raise_error
+      describe 'when a subclass of Safeguard::Base is defined' do
+        before do
+          class AlwaysRaise < DatabaseCleaner::Safeguard::Base
+            def run
+              raise "Some error"
             end
           end
         end
 
-        let(:url_allowlist) do
-          [
-            'postgres://postgres@localhost',
-            'postgres://foo.bar',
-            %r{^postgres://bar.baz},
-            proc { |x| URI.parse(x).user == 'test' }
-          ]
+        after { DatabaseCleaner.send(:remove_const, :AlwaysRaise) if DatabaseCleaner.const_defined?(:AlwaysRaise) }
+
+        it 'is run' do
+          expect { cleaner.start }.to raise_error("Some error")
+        end
+      end
+
+      describe 'when a subclass of Safeguard::Base shares the name of a Safeguard defined in core' do
+        before do
+          class RemoteDatabaseUrl < DatabaseCleaner::Safeguard::Base
+            def run
+              :ok
+            end
+          end
         end
 
-        describe 'url_allowlist' do
-          before { DatabaseCleaner.url_allowlist = url_allowlist }
-          after  { DatabaseCleaner.url_allowlist = nil }
-          it_behaves_like 'allowlist assigned'
-        end
+        after { DatabaseCleaner.send(:remove_const, :RemoteDatabaseUrl) if DatabaseCleaner.const_defined?(:RemoteDatabaseUrl) }
 
-        describe 'url_whitelist' do
-          before { DatabaseCleaner.url_whitelist = url_allowlist }
-          after  { DatabaseCleaner.url_whitelist = nil }
-          it_behaves_like 'allowlist assigned'
-        end
+        it 'runs the Safeguard::Base subclass instead' do
+          expect_any_instance_of(described_class::RemoteDatabaseUrl).not_to receive(:run)
+          expect_any_instance_of(RemoteDatabaseUrl).to receive(:run)
 
+          cleaner.start
+        end
       end
     end
 
-    describe 'ENV is set to production' do
-      %w(ENV APP_ENV RACK_ENV RAILS_ENV).each do |key|
-        describe "on #{key}" do
-          before { stub_const('ENV', key => "production") }
+    describe 'behavior of deprecated, core Safeguards' do
+      describe 'DATABASE_URL is set' do
+        before { stub_const('ENV', 'DATABASE_URL' => database_url) }
+
+        describe 'to any value' do
+          let(:database_url) { 'postgres://remote.host' }
 
           it 'raises' do
-            expect { cleaner.start }.to raise_error(Safeguard::Error::ProductionEnv)
+            expect { cleaner.start }.to raise_error(Safeguard::Error::RemoteDatabaseUrl)
           end
         end
 
-        describe 'DATABASE_CLEANER_ALLOW_PRODUCTION is set' do
-          before { stub_const('ENV', 'DATABASE_CLEANER_ALLOW_PRODUCTION' => true) }
+        describe 'to a localhost url' do
+          let(:database_url) { 'postgres://localhost' }
 
           it 'does not raise' do
             expect { cleaner.start }.to_not raise_error
           end
         end
 
-        describe 'DatabaseCleaner.allow_production is true' do
-          before { DatabaseCleaner.allow_production = true }
-          after  { DatabaseCleaner.allow_production = nil }
+        describe 'to a local, empty-host url' do
+          let(:database_url) { 'postgres:///' }
 
           it 'does not raise' do
             expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'to a local tld url' do
+          let(:database_url) { 'postgres://postgres.local' }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'to a 127.0.0.1 url' do
+          let(:database_url) { 'postgres://127.0.0.1' }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'to a sqlite url' do
+          let(:database_url) { 'sqlite://tmp/db.sqlite3' }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'to a sqlite3 url' do
+          let(:database_url) { 'sqlite3://tmp/db.sqlite3' }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'to a sqlite3 url with no slashes after the scheme' do
+          let(:database_url) { 'sqlite3:tmp/db.sqlite3' }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL is set' do
+          let(:database_url) { 'postgres://remote.host' }
+          before { stub_const('ENV', 'DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL' => true) }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'DatabaseCleaner.allow_remote_database_url is true' do
+          let(:database_url) { 'postgres://remote.host' }
+          before { DatabaseCleaner.allow_remote_database_url = true }
+          after  { DatabaseCleaner.allow_remote_database_url = nil }
+
+          it 'does not raise' do
+            expect { cleaner.start }.to_not raise_error
+          end
+        end
+
+        describe 'DatabaseCleaner.url_allowlist is set' do
+
+          shared_examples 'allowlist assigned' do
+            describe 'A remote url is on the allowlist' do
+              let(:database_url) { 'postgres://foo.bar' }
+
+              it 'does not raise' do
+                expect { cleaner.start }.to_not raise_error
+              end
+            end
+
+            describe 'A remote url is not on the allowlist' do
+              let(:database_url) { 'postgress://bar.baz' }
+
+              it 'raises a not allowed error' do
+                expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
+              end
+            end
+
+            describe 'A similar url not explicitly matched as a pattern' do
+              let(:database_url) { 'postgres://foo.bar?pool=8' }
+
+              it 'raises a not allowed error' do
+                expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
+              end
+            end
+
+            describe 'A remote url matches a pattern on the allowlist' do
+              let(:database_url) { 'postgres://bar.baz?pool=16' }
+
+              it 'does not raise' do
+                expect { cleaner.start }.to_not raise_error
+              end
+            end
+
+            describe 'A local url is on the allowlist' do
+              let(:database_url) { 'postgres://postgres@localhost' }
+
+              it 'does not raise' do
+                expect { cleaner.start }.to_not raise_error
+              end
+            end
+
+            describe 'A local url is not on the allowlist' do
+              let(:database_url) { 'postgres://localhost' }
+
+              it 'raises a not allowed error' do
+                expect { cleaner.start }.to raise_error(Safeguard::Error::UrlNotAllowed)
+              end
+            end
+
+            describe 'A url that matches a proc' do
+              let(:database_url) { 'redis://test:test@foo.bar' }
+
+              it 'does not raise' do
+                expect { cleaner.start }.to_not raise_error
+              end
+            end
+          end
+
+          let(:url_allowlist) do
+            [
+              'postgres://postgres@localhost',
+              'postgres://foo.bar',
+              %r{^postgres://bar.baz},
+              proc { |x| URI.parse(x).user == 'test' }
+            ]
+          end
+
+          describe 'url_allowlist' do
+            before { DatabaseCleaner.url_allowlist = url_allowlist }
+            after  { DatabaseCleaner.url_allowlist = nil }
+            it_behaves_like 'allowlist assigned'
+          end
+
+          describe 'url_whitelist' do
+            before { DatabaseCleaner.url_whitelist = url_allowlist }
+            after  { DatabaseCleaner.url_whitelist = nil }
+            it_behaves_like 'allowlist assigned'
+          end
+
+        end
+      end
+
+      describe 'ENV is set to production' do
+        %w(ENV APP_ENV RACK_ENV RAILS_ENV).each do |key|
+          describe "on #{key}" do
+            before { stub_const('ENV', key => "production") }
+
+            it 'raises' do
+              expect { cleaner.start }.to raise_error(Safeguard::Error::ProductionEnv)
+            end
+          end
+
+          describe 'DATABASE_CLEANER_ALLOW_PRODUCTION is set' do
+            before { stub_const('ENV', 'DATABASE_CLEANER_ALLOW_PRODUCTION' => true) }
+
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
+          end
+
+          describe 'DatabaseCleaner.allow_production is true' do
+            before { DatabaseCleaner.allow_production = true }
+            after  { DatabaseCleaner.allow_production = nil }
+
+            it 'does not raise' do
+              expect { cleaner.start }.to_not raise_error
+            end
           end
         end
       end


### PR DESCRIPTION
Allow consumers to define their own safeguards and maintain existing behavior for backwards compatibility.

- Updates `Safeguard` to use a registry
	Similar to how RuboCop handles Cops from itself, gems, plugins, and local repos. `Safeguard.run` executes each registered safeguard.
- Adds `Safeguard::Base` class
	Consumers can create new safeguards by inheriting this class. Safeguards are added to the registry through `inherited`.
- Adds `Safeguard::Deprecated` class
	Just a marker for the existing core-defined safeguards. The idea is that these would eventually get deleted after the adapters are updated to implement their own.
- Enables "overriding" of core-defined safeguards
	If a safeguard is registered by the same name as a deprecated safeguard it will be executed instead. 

This will allow the resolution issues like #659 and #684 by enabling adapters (or users) to define their own safeguards.

For example, to resolve #684 `database_cleaner-active_record` can implement its own `AllowedUrl` to override the existing behavior.

Simplified example:
```yaml
# config/database.yml
test:
  adapter: postgresql
  host: postgres
  port: 5432
  database: myapp_test
  username: dbuser
  password: dbpassword
  pool: 5
  encoding: unicode
```

```ruby
module DatabaseCleaner
  module ActiveRecord
    module Safeguards
      class AllowedUrl < DatabaseCleaner::Safeguard::Base
        def run
          return if skip?
          raise Error::UrlNotAllowed if database_url_not_allowed?
        end

        private

          def database_url_not_allowed?
            !DatabaseCleaner.url_allowlist.any? {|allowed| allowed === database_url }
          end  
         
         # ...
         
          def database_url
            return ENV['DATABASE_URL'] unless ENV['DATABASE_URL'].nil? || ENV['DATABASE_URL'].strip.empty?

            # ...build a connection url from ::ActiveRecord::Base.connection_db_config
            # => "postgresql://dbuser:dbpassword@postgres:5432/myapp_test=5&encoding=unicode"
          end
      end
    end
  end
end
```