### PR TITLE
[DX] Improve CONTRIBUTE.md instructions

### DIFF
--- a/CONTRIBUTE.markdown
+++ b/CONTRIBUTE.markdown
@@ -12,10 +12,10 @@ upstream:
 
 - `bundle install`
 - Copy `spec/support/sample.config.yml` to `spec/support/config.yml` and edit it
-- Run the tests with `bundle exec rspec`
+- Run the tests with `bundle exec rspec` and `bundle exec cucumber`
 
-Note that if you don't have all the supported databases installed and running,
-some tests will fail.
+Note that the Cucumber specs require `redis` to be running, you can either run it globally
+on your system or use the provided `docker-compose.yml` file and run `docker compose up`.
 
 ## 3. Prepare your contribution
 

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,5 +1,8 @@
 == Development (unreleased)
 
+== Chores
+  * Update CONTRIBUTE.md to mention Cucumber specs and Redis dependency https://github.com/DatabaseCleaner/database_cleaner/pull/721
+
 == 2.1.0 2024-10-24
 
 === Changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  redis:
+    image: redis:6.2-alpine
+    restart: always
+    ports:
+      - '127.0.0.1:6379:6379'
+    command: redis-server --save 20 1 --loglevel warning


### PR DESCRIPTION
This PR make 2 small improvements to the CONTRIBUTE.md file:
- added instructions to run the cucumber specs
- specify that only redis is needed for the core tests

I also added a docker-compose.yml file so redis can be run through docker if the user doesn't want to install it system-wide.